### PR TITLE
Add build to binary heap

### DIFF
--- a/trees/binaryheap/binaryheap.go
+++ b/trees/binaryheap/binaryheap.go
@@ -50,6 +50,17 @@ func (heap *Heap) Push(value interface{}) {
 	heap.bubbleUp()
 }
 
+// Build adds a values onto the heap and order them up accordingly.
+func (heap *Heap) Build(values ...interface{}) {
+	for _, value := range values {
+		heap.list.Add(value)
+	}
+	size := heap.list.Size()/2 + 1
+	for i := size; i >= 0; i-- {
+		heap.bubbleDownIndex(i)
+	}
+}
+
 // Pop removes top element on heap and returns it, or nil if heap is empty.
 // Second return parameter is true, unless the heap was empty and there was nothing to pop.
 func (heap *Heap) Pop() (value interface{}, ok bool) {
@@ -101,10 +112,14 @@ func (heap *Heap) String() string {
 	return str
 }
 
+// Performs the "bubble down" operation for the 1st element.
+func (heap *Heap) bubbleDown() {
+	heap.bubbleDownIndex(0)
+}
+
 // Performs the "bubble down" operation. This is to place the element that is at the
 // root of the heap in its correct place so that the heap maintains the min/max-heap order property.
-func (heap *Heap) bubbleDown() {
-	index := 0
+func (heap *Heap) bubbleDownIndex(index int) {
 	size := heap.list.Size()
 	for leftIndex := index<<1 + 1; leftIndex < size; leftIndex = index<<1 + 1 {
 		rightIndex := index<<1 + 2

--- a/trees/binaryheap/binaryheap_test.go
+++ b/trees/binaryheap/binaryheap_test.go
@@ -34,6 +34,23 @@ func TestBinaryHeapPush(t *testing.T) {
 	}
 }
 
+func TestBinaryHeapBuild(t *testing.T) {
+	heap := NewWithIntComparator()
+
+	if actualValue := heap.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+
+	heap.Build(15, 20, 3, 1, 2)
+
+	if actualValue := heap.Values(); actualValue[0].(int) != 1 || actualValue[1].(int) != 2 || actualValue[2].(int) != 3 {
+		t.Errorf("Got %v expected %v", actualValue, "[1,2,3]")
+	}
+	if actualValue, ok := heap.Pop(); actualValue != 1 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 1)
+	}
+}
+
 func TestBinaryHeapPop(t *testing.T) {
 	heap := NewWithIntComparator()
 


### PR DESCRIPTION
This changes allow to build heap from slice in O(n) time.

There was a proposition to add slicer interface(example https://play.golang.org/p/lpOt0Lw_pM) so it will be possible to use construction like: 
```
a := []int{1,2,3,4,5}
heap.Build(a)
```
Are you okay with this solution?