### PR TITLE
TimeComparator

### DIFF
--- a/utils/comparator.go
+++ b/utils/comparator.go
@@ -53,7 +53,7 @@ func IntComparator(a, b interface{}) int {
 	}
 }
 
-// IntComparator provides a basic comparison on int
+// TimeComparator provides a basic comparison on time.Time
 func TimeComparator(a, b interface{}) int {
 	aAsserted := a.(time.Time)
 	bAsserted := b.(time.Time)

--- a/utils/comparator.go
+++ b/utils/comparator.go
@@ -4,6 +4,8 @@
 
 package utils
 
+import "time"
+
 // Comparator will make type assertion (see IntComparator for example),
 // which will panic if a or b are not of the asserted type.
 //
@@ -45,6 +47,21 @@ func IntComparator(a, b interface{}) int {
 	case aAsserted > bAsserted:
 		return 1
 	case aAsserted < bAsserted:
+		return -1
+	default:
+		return 0
+	}
+}
+
+// IntComparator provides a basic comparison on int
+func TimeComparator(a, b interface{}) int {
+	aAsserted := a.(time.Time)
+	bAsserted := b.(time.Time)
+
+	switch {
+	case aAsserted.After(bAsserted) :
+		return 1
+	case aAsserted.Before(bAsserted):
 		return -1
 	default:
 		return 0

--- a/utils/comparator_test.go
+++ b/utils/comparator_test.go
@@ -6,6 +6,7 @@ package utils
 
 import (
 	"testing"
+	"time"
 )
 
 func TestIntComparator(t *testing.T) {
@@ -23,6 +24,27 @@ func TestIntComparator(t *testing.T) {
 
 	for _, test := range tests {
 		actual := IntComparator(test[0], test[1])
+		expected := test[2]
+		if actual != expected {
+			t.Errorf("Got %v expected %v", actual, expected)
+		}
+	}
+}
+
+
+func TestTimeComparator(t *testing.T) {
+
+	now := time.Now()
+
+	// i1,i2,expected
+	tests := [][]interface{}{
+		{now, now, 0},
+		{now.Add(24 * 7 * 2 * time.Hour), now, 1},
+		{now, now.Add(24 * 7 * 2 * time.Hour), -1},
+	}
+
+	for _, test := range tests {
+		actual := TimeComparator(test[0], test[1])
 		expected := test[2]
 		if actual != expected {
 			t.Errorf("Got %v expected %v", actual, expected)


### PR DESCRIPTION
We added a time comparison. 
We use TreeMaps with times extensively. 
The guess is that others do this is as well.

#### Small addition
```golang
// TimeComparator provides a basic comparison on time.Time
func TimeComparator(a, b interface{}) int {
	aAsserted := a.(time.Time)
	bAsserted := b.(time.Time)

	switch {
	case aAsserted.After(bAsserted) :
		return 1
	case aAsserted.Before(bAsserted):
		return -1
	default:
		return 0
	}
}
```

With a test case. 

```golang
func TestTimeComparator(t *testing.T) {

	now := time.Now()

	// i1,i2,expected
	tests := [][]interface{}{
		{now, now, 0},
		{now.Add(24 * 7 * 2 * time.Hour), now, 1},
		{now, now.Add(24 * 7 * 2 * time.Hour), -1},
	}

	for _, test := range tests {
		actual := TimeComparator(test[0], test[1])
		expected := test[2]
		if actual != expected {
			t.Errorf("Got %v expected %v", actual, expected)
		}
	}
}
```