### PR TITLE
Switch default tree implementation over to AVL

### DIFF
--- a/maps/treebidimap/iterator.go
+++ b/maps/treebidimap/iterator.go
@@ -6,7 +6,7 @@ package treebidimap
 
 import (
 	"github.com/emirpasic/gods/containers"
-	rbt "github.com/emirpasic/gods/trees/redblacktree"
+	avl "github.com/spewspews/gods/trees/avltree"
 )
 
 func assertIteratorImplementation() {
@@ -15,7 +15,7 @@ func assertIteratorImplementation() {
 
 // Iterator holding the iterator's state
 type Iterator struct {
-	iterator rbt.Iterator
+	iterator avl.Iterator
 }
 
 // Iterator returns a stateful iterator whose elements are key/value pairs.

--- a/maps/treebidimap/treebidimap.go
+++ b/maps/treebidimap/treebidimap.go
@@ -20,7 +20,7 @@ package treebidimap
 import (
 	"fmt"
 	"github.com/emirpasic/gods/maps"
-	"github.com/emirpasic/gods/trees/redblacktree"
+	"github.com/spewspews/gods/trees/avltree"
 	"github.com/emirpasic/gods/utils"
 	"strings"
 )
@@ -31,8 +31,8 @@ func assertMapImplementation() {
 
 // Map holds the elements in two red-black trees.
 type Map struct {
-	forwardMap      redblacktree.Tree
-	inverseMap      redblacktree.Tree
+	forwardMap      avltree.Tree
+	inverseMap      avltree.Tree
 	keyComparator   utils.Comparator
 	valueComparator utils.Comparator
 }
@@ -45,8 +45,8 @@ type data struct {
 // NewWith instantiates a bidirectional map.
 func NewWith(keyComparator utils.Comparator, valueComparator utils.Comparator) *Map {
 	return &Map{
-		forwardMap:      *redblacktree.NewWith(keyComparator),
-		inverseMap:      *redblacktree.NewWith(valueComparator),
+		forwardMap:      *avltree.NewWith(keyComparator),
+		inverseMap:      *avltree.NewWith(valueComparator),
 		keyComparator:   keyComparator,
 		valueComparator: valueComparator,
 	}

--- a/maps/treemap/enumerable.go
+++ b/maps/treemap/enumerable.go
@@ -6,7 +6,7 @@ package treemap
 
 import (
 	"github.com/emirpasic/gods/containers"
-	rbt "github.com/emirpasic/gods/trees/redblacktree"
+	avl "github.com/spewspews/gods/trees/avltree"
 )
 
 func assertEnumerableImplementation() {
@@ -24,7 +24,7 @@ func (m *Map) Each(f func(key interface{}, value interface{})) {
 // Map invokes the given function once for each element and returns a container
 // containing the values returned by the given function as key/value pairs.
 func (m *Map) Map(f func(key1 interface{}, value1 interface{}) (interface{}, interface{})) *Map {
-	newMap := &Map{tree: rbt.NewWith(m.tree.Comparator)}
+	newMap := &Map{tree: avl.NewWith(m.tree.Comparator)}
 	iterator := m.Iterator()
 	for iterator.Next() {
 		key2, value2 := f(iterator.Key(), iterator.Value())
@@ -35,7 +35,7 @@ func (m *Map) Map(f func(key1 interface{}, value1 interface{}) (interface{}, int
 
 // Select returns a new container containing all elements for which the given function returns a true value.
 func (m *Map) Select(f func(key interface{}, value interface{}) bool) *Map {
-	newMap := &Map{tree: rbt.NewWith(m.tree.Comparator)}
+	newMap := &Map{tree: avl.NewWith(m.tree.Comparator)}
 	iterator := m.Iterator()
 	for iterator.Next() {
 		if f(iterator.Key(), iterator.Value()) {

--- a/maps/treemap/iterator.go
+++ b/maps/treemap/iterator.go
@@ -6,7 +6,7 @@ package treemap
 
 import (
 	"github.com/emirpasic/gods/containers"
-	rbt "github.com/emirpasic/gods/trees/redblacktree"
+	avl "github.com/spewspews/gods/trees/avltree"
 )
 
 func assertIteratorImplementation() {
@@ -15,7 +15,7 @@ func assertIteratorImplementation() {
 
 // Iterator holding the iterator's state
 type Iterator struct {
-	iterator rbt.Iterator
+	iterator avl.Iterator
 }
 
 // Iterator returns a stateful iterator whose elements are key/value pairs.

--- a/maps/treemap/treemap.go
+++ b/maps/treemap/treemap.go
@@ -14,7 +14,7 @@ package treemap
 import (
 	"fmt"
 	"github.com/emirpasic/gods/maps"
-	rbt "github.com/emirpasic/gods/trees/redblacktree"
+	avl "github.com/spewspews/gods/trees/avltree"
 	"github.com/emirpasic/gods/utils"
 	"strings"
 )
@@ -25,22 +25,22 @@ func assertMapImplementation() {
 
 // Map holds the elements in a red-black tree
 type Map struct {
-	tree *rbt.Tree
+	tree *avl.Tree
 }
 
 // NewWith instantiates a tree map with the custom comparator.
 func NewWith(comparator utils.Comparator) *Map {
-	return &Map{tree: rbt.NewWith(comparator)}
+	return &Map{tree: avl.NewWith(comparator)}
 }
 
 // NewWithIntComparator instantiates a tree map with the IntComparator, i.e. keys are of type int.
 func NewWithIntComparator() *Map {
-	return &Map{tree: rbt.NewWithIntComparator()}
+	return &Map{tree: avl.NewWithIntComparator()}
 }
 
 // NewWithStringComparator instantiates a tree map with the StringComparator, i.e. keys are of type string.
 func NewWithStringComparator() *Map {
-	return &Map{tree: rbt.NewWithStringComparator()}
+	return &Map{tree: avl.NewWithStringComparator()}
 }
 
 // Put inserts key-value pair into the map.

--- a/sets/treeset/enumerable.go
+++ b/sets/treeset/enumerable.go
@@ -6,7 +6,7 @@ package treeset
 
 import (
 	"github.com/emirpasic/gods/containers"
-	rbt "github.com/emirpasic/gods/trees/redblacktree"
+	avl "github.com/spewspews/gods/trees/avltree"
 )
 
 func assertEnumerableImplementation() {
@@ -24,7 +24,7 @@ func (set *Set) Each(f func(index int, value interface{})) {
 // Map invokes the given function once for each element and returns a
 // container containing the values returned by the given function.
 func (set *Set) Map(f func(index int, value interface{}) interface{}) *Set {
-	newSet := &Set{tree: rbt.NewWith(set.tree.Comparator)}
+	newSet := &Set{tree: avl.NewWith(set.tree.Comparator)}
 	iterator := set.Iterator()
 	for iterator.Next() {
 		newSet.Add(f(iterator.Index(), iterator.Value()))
@@ -34,7 +34,7 @@ func (set *Set) Map(f func(index int, value interface{}) interface{}) *Set {
 
 // Select returns a new container containing all elements for which the given function returns a true value.
 func (set *Set) Select(f func(index int, value interface{}) bool) *Set {
-	newSet := &Set{tree: rbt.NewWith(set.tree.Comparator)}
+	newSet := &Set{tree: avl.NewWith(set.tree.Comparator)}
 	iterator := set.Iterator()
 	for iterator.Next() {
 		if f(iterator.Index(), iterator.Value()) {

--- a/sets/treeset/iterator.go
+++ b/sets/treeset/iterator.go
@@ -6,7 +6,7 @@ package treeset
 
 import (
 	"github.com/emirpasic/gods/containers"
-	rbt "github.com/emirpasic/gods/trees/redblacktree"
+	avl "github.com/spewspews/gods/trees/avltree"
 )
 
 func assertIteratorImplementation() {
@@ -16,8 +16,8 @@ func assertIteratorImplementation() {
 // Iterator returns a stateful iterator whose values can be fetched by an index.
 type Iterator struct {
 	index    int
-	iterator rbt.Iterator
-	tree     *rbt.Tree
+	iterator avl.Iterator
+	tree     *avl.Tree
 }
 
 // Iterator holding the iterator's state

--- a/sets/treeset/treeset.go
+++ b/sets/treeset/treeset.go
@@ -12,7 +12,7 @@ package treeset
 import (
 	"fmt"
 	"github.com/emirpasic/gods/sets"
-	rbt "github.com/emirpasic/gods/trees/redblacktree"
+	avl "github.com/spewspews/gods/trees/avltree"
 	"github.com/emirpasic/gods/utils"
 	"strings"
 )
@@ -23,24 +23,24 @@ func assertSetImplementation() {
 
 // Set holds elements in a red-black tree
 type Set struct {
-	tree *rbt.Tree
+	tree *avl.Tree
 }
 
 var itemExists = struct{}{}
 
 // NewWith instantiates a new empty set with the custom comparator.
 func NewWith(comparator utils.Comparator) *Set {
-	return &Set{tree: rbt.NewWith(comparator)}
+	return &Set{tree: avl.NewWith(comparator)}
 }
 
 // NewWithIntComparator instantiates a new empty set with the IntComparator, i.e. keys are of type int.
 func NewWithIntComparator() *Set {
-	return &Set{tree: rbt.NewWithIntComparator()}
+	return &Set{tree: avl.NewWithIntComparator()}
 }
 
 // NewWithStringComparator instantiates a new empty set with the StringComparator, i.e. keys are of type string.
 func NewWithStringComparator() *Set {
-	return &Set{tree: rbt.NewWithStringComparator()}
+	return &Set{tree: avl.NewWithStringComparator()}
 }
 
 // Add adds the items (one or more) to the set.

--- a/trees/avltree/iterator.go
+++ b/trees/avltree/iterator.go
@@ -24,8 +24,8 @@ const (
 )
 
 // Iterator returns a stateful iterator whose elements are key/value pairs.
-func (tree *Tree) Iterator() containers.ReverseIteratorWithKey {
-	return &Iterator{tree: tree, node: nil, position: begin}
+func (tree *Tree) Iterator() Iterator {
+	return Iterator{tree: tree, node: nil, position: begin}
 }
 
 // Next moves the iterator to the next element and returns true if there was a next element in the container.


### PR DESCRIPTION
Hi Emir,

I know I'm admittedly a bit biased regarding the implementation but I was wondering if you might be interested in switching the default tree implementation over to AVL. The only reason I ask is because I was taking a look at the benchmarks and I was seeing much faster numbers on Put and Get and essentially equivalent numbers on Delete. In my opinion the increase in speed to Put and Get is important since those operations are typically used the most. I put some benches below but of course, just run them yourself. So if you are interested in making the change, then this pull request will do it. Just change the `spewspews` back to `emirpasic` (I had to change the return type of avltree.Interface())

```
[0 conejo@redblacktree]$ go test -bench=.
BenchmarkRedBlackTreeGet100-4         	  200000	      8082 ns/op
BenchmarkRedBlackTreeGet1000-4        	   10000	    125199 ns/op
BenchmarkRedBlackTreeGet10000-4       	    1000	   1626729 ns/op
BenchmarkRedBlackTreeGet100000-4      	     100	  19570779 ns/op
BenchmarkRedBlackTreePut100-4         	  100000	     22915 ns/op
BenchmarkRedBlackTreePut1000-4        	   10000	    269164 ns/op
BenchmarkRedBlackTreePut10000-4       	     500	   3133202 ns/op
BenchmarkRedBlackTreePut100000-4      	      50	  32673103 ns/op
BenchmarkRedBlackTreeRemove100-4      	  300000	      4260 ns/op
BenchmarkRedBlackTreeRemove1000-4     	   30000	     42917 ns/op
BenchmarkRedBlackTreeRemove10000-4    	    3000	    428098 ns/op
BenchmarkRedBlackTreeRemove100000-4   	     300	   4216734 ns/op
PASS
ok  	github.com/spewspews/gods/trees/redblacktree	21.984s
[0 conejo@redblacktree]$ c ../avltree/
[0 conejo@avltree]$ go test -bench=.
BenchmarkAVLTreeGet100-4         	  200000	      7359 ns/op
BenchmarkAVLTreeGet1000-4        	   10000	    120219 ns/op
BenchmarkAVLTreeGet10000-4       	    1000	   1424679 ns/op
BenchmarkAVLTreeGet100000-4      	     100	  18255855 ns/op
BenchmarkAVLTreePut100-4         	  200000	     11601 ns/op
BenchmarkAVLTreePut1000-4        	   10000	    179913 ns/op
BenchmarkAVLTreePut10000-4       	    1000	   2462981 ns/op
BenchmarkAVLTreePut100000-4      	      50	  27307587 ns/op
BenchmarkAVLTreeRemove100-4      	  300000	      4370 ns/op
BenchmarkAVLTreeRemove1000-4     	   30000	     44783 ns/op
BenchmarkAVLTreeRemove10000-4    	    3000	    435508 ns/op
BenchmarkAVLTreeRemove100000-4   	     300	   4376341 ns/op
PASS
ok  	github.com/spewspews/gods/trees/avltree	21.168s
[0 conejo@avltree]$ c ../redblacktree/
[0 conejo@redblacktree]$ go test -bench=.
BenchmarkRedBlackTreeGet100-4         	  200000	      7984 ns/op
BenchmarkRedBlackTreeGet1000-4        	   10000	    127274 ns/op
BenchmarkRedBlackTreeGet10000-4       	    1000	   1501437 ns/op
BenchmarkRedBlackTreeGet100000-4      	     100	  18581652 ns/op
BenchmarkRedBlackTreePut100-4         	   50000	     22363 ns/op
BenchmarkRedBlackTreePut1000-4        	    5000	    276150 ns/op
BenchmarkRedBlackTreePut10000-4       	     500	   3254391 ns/op
BenchmarkRedBlackTreePut100000-4      	      50	  32521572 ns/op
BenchmarkRedBlackTreeRemove100-4      	  500000	      4253 ns/op
BenchmarkRedBlackTreeRemove1000-4     	   30000	     41033 ns/op
BenchmarkRedBlackTreeRemove10000-4    	    5000	    430048 ns/op
BenchmarkRedBlackTreeRemove100000-4   	     300	   4346227 ns/op
PASS
ok  	github.com/spewspews/gods/trees/redblacktree	21.015s
[0 conejo@redblacktree]$ c ../avltree/
[0 conejo@avltree]$ go test -bench=.
BenchmarkAVLTreeGet100-4         	  200000	      7558 ns/op
BenchmarkAVLTreeGet1000-4        	   10000	    123012 ns/op
BenchmarkAVLTreeGet10000-4       	    1000	   1476524 ns/op
BenchmarkAVLTreeGet100000-4      	     100	  18166543 ns/op
BenchmarkAVLTreePut100-4         	  200000	     11828 ns/op
BenchmarkAVLTreePut1000-4        	   10000	    172504 ns/op
BenchmarkAVLTreePut10000-4       	    1000	   2124155 ns/op
BenchmarkAVLTreePut100000-4      	      50	  27904278 ns/op
BenchmarkAVLTreeRemove100-4      	  300000	      4428 ns/op
BenchmarkAVLTreeRemove1000-4     	   30000	     42913 ns/op
BenchmarkAVLTreeRemove10000-4    	    5000	    431223 ns/op
BenchmarkAVLTreeRemove100000-4   	     300	   4433945 ns/op
PASS
ok  	github.com/spewspews/gods/trees/avltree	21.677s
```