### PR TITLE
Added bulk constructors for arraylists & (doubly)-linked-lists

### DIFF
--- a/lists/arraylist/arraylist.go
+++ b/lists/arraylist/arraylist.go
@@ -11,9 +11,10 @@ package arraylist
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertListImplementation() {
@@ -34,6 +35,13 @@ const (
 // New instantiates a new empty list
 func New() *List {
 	return &List{}
+}
+
+// Of instantiates a new list of the given values
+func Of(values ...interface{}) *List {
+	list := New()
+	list.Add(values)
+	return list
 }
 
 // Add appends a value at the end of the list

--- a/lists/doublylinkedlist/doublylinkedlist.go
+++ b/lists/doublylinkedlist/doublylinkedlist.go
@@ -11,9 +11,10 @@ package doublylinkedlist
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertListImplementation() {
@@ -36,6 +37,13 @@ type element struct {
 // New instantiates a new empty list
 func New() *List {
 	return &List{}
+}
+
+// Of instantiates a new list of the given values
+func Of(values ...interface{}) *List {
+	list := New()
+	list.Add(values)
+	return list
 }
 
 // Add appends a value (one or more) at the end of the list (same as Append())

--- a/lists/singlylinkedlist/singlylinkedlist.go
+++ b/lists/singlylinkedlist/singlylinkedlist.go
@@ -11,9 +11,10 @@ package singlylinkedlist
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertListImplementation() {
@@ -35,6 +36,13 @@ type element struct {
 // New instantiates a new empty list
 func New() *List {
 	return &List{}
+}
+
+// Of instantiates a new list of the given values
+func Of(values ...interface{}) *List {
+	list := New()
+	list.Add(values)
+	return list
 }
 
 // Add appends a value (one or more) at the end of the list (same as Append())


### PR DESCRIPTION
Hi following #36 I have implemented a simple bulk constructor for all 3 types of lists.

* arraylist
* linkedlist
* doublylinkedlist

You can use it as follows:

```go
list := arraylist.Of(0, 1 , "a", "b", 4.3)
```