### PR TITLE
Changed initial String() functions for better real-application use.

### DIFF
--- a/lists/arraylist/arraylist.go
+++ b/lists/arraylist/arraylist.go
@@ -11,9 +11,10 @@ package arraylist
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertListImplementation() {
@@ -157,12 +158,12 @@ func (list *List) Insert(index int, values ...interface{}) {
 
 // String returns a string representation of container
 func (list *List) String() string {
-	str := "ArrayList\n"
+	str := "["
 	values := []string{}
 	for _, value := range list.elements[:list.size] {
 		values = append(values, fmt.Sprintf("%v", value))
 	}
-	str += strings.Join(values, ", ")
+	str += strings.Join(values, ", ") + "]"
 	return str
 }
 

--- a/lists/doublylinkedlist/doublylinkedlist.go
+++ b/lists/doublylinkedlist/doublylinkedlist.go
@@ -11,9 +11,10 @@ package doublylinkedlist
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertListImplementation() {
@@ -281,12 +282,12 @@ func (list *List) Insert(index int, values ...interface{}) {
 
 // String returns a string representation of container
 func (list *List) String() string {
-	str := "DoublyLinkedList\n"
+	str := "["
 	values := []string{}
 	for element := list.first; element != nil; element = element.next {
 		values = append(values, fmt.Sprintf("%v", element.value))
 	}
-	str += strings.Join(values, ", ")
+	str += strings.Join(values, ", ") + "]"
 	return str
 }
 

--- a/lists/singlylinkedlist/singlylinkedlist.go
+++ b/lists/singlylinkedlist/singlylinkedlist.go
@@ -11,9 +11,10 @@ package singlylinkedlist
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertListImplementation() {
@@ -249,12 +250,12 @@ func (list *List) Insert(index int, values ...interface{}) {
 
 // String returns a string representation of container
 func (list *List) String() string {
-	str := "SinglyLinkedList\n"
+	str := "["
 	values := []string{}
 	for element := list.first; element != nil; element = element.next {
 		values = append(values, fmt.Sprintf("%v", element.value))
 	}
-	str += strings.Join(values, ", ")
+	str += strings.Join(values, ", ") + "]"
 	return str
 }
 

--- a/maps/hashbidimap/hashbidimap.go
+++ b/maps/hashbidimap/hashbidimap.go
@@ -16,7 +16,6 @@
 package hashbidimap
 
 import (
-	"fmt"
 	"github.com/emirpasic/gods/maps"
 	"github.com/emirpasic/gods/maps/hashmap"
 )
@@ -96,7 +95,5 @@ func (m *Map) Clear() {
 
 // String returns a string representation of container
 func (m *Map) String() string {
-	str := "HashBidiMap\n"
-	str += fmt.Sprintf("%v", m.forwardMap)
-	return str
+	return m.forwardMap.String()
 }

--- a/maps/hashmap/hashmap.go
+++ b/maps/hashmap/hashmap.go
@@ -13,6 +13,9 @@ package hashmap
 
 import (
 	"fmt"
+
+	"strings"
+
 	"github.com/emirpasic/gods/maps"
 )
 
@@ -86,7 +89,11 @@ func (m *Map) Clear() {
 
 // String returns a string representation of container
 func (m *Map) String() string {
-	str := "HashMap\n"
-	str += fmt.Sprintf("%v", m.m)
+	str := "{"
+	values := []string{}
+	for k, v := range m.m {
+		values = append(values, fmt.Sprintf("%#v: %#v", k, v))
+	}
+	str += strings.Join(values, ", ") + "}"
 	return str
 }

--- a/maps/treebidimap/treebidimap.go
+++ b/maps/treebidimap/treebidimap.go
@@ -19,10 +19,11 @@ package treebidimap
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/maps"
 	"github.com/emirpasic/gods/trees/redblacktree"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertMapImplementation() {
@@ -129,10 +130,12 @@ func (m *Map) Clear() {
 
 // String returns a string representation of container
 func (m *Map) String() string {
-	str := "TreeBidiMap\nmap["
+	str := "{"
+	values := []string{}
 	it := m.Iterator()
 	for it.Next() {
-		str += fmt.Sprintf("%v:%v ", it.Key(), it.Value())
+		values = append(values, fmt.Sprintf("%#v: %#v", it.Key(), it.Value()))
 	}
-	return strings.TrimRight(str, " ") + "]"
+	str += strings.Join(values, ", ") + "}"
+	return str
 }

--- a/maps/treemap/treemap.go
+++ b/maps/treemap/treemap.go
@@ -13,10 +13,11 @@ package treemap
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/maps"
 	rbt "github.com/emirpasic/gods/trees/redblacktree"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertMapImplementation() {
@@ -107,11 +108,12 @@ func (m *Map) Max() (key interface{}, value interface{}) {
 
 // String returns a string representation of container
 func (m *Map) String() string {
-	str := "TreeMap\nmap["
+	str := "{"
+	values := []string{}
 	it := m.Iterator()
 	for it.Next() {
-		str += fmt.Sprintf("%v:%v ", it.Key(), it.Value())
+		values = append(values, fmt.Sprintf("%#v: %#v", it.Key(), it.Value()))
 	}
-	return strings.TrimRight(str, " ") + "]"
-
+	str += strings.Join(values, ", ") + "}"
+	return str
 }

--- a/sets/hashset/hashset.go
+++ b/sets/hashset/hashset.go
@@ -11,8 +11,9 @@ package hashset
 
 import (
 	"fmt"
-	"github.com/emirpasic/gods/sets"
 	"strings"
+
+	"github.com/emirpasic/gods/sets"
 )
 
 func assertSetImplementation() {
@@ -85,11 +86,11 @@ func (set *Set) Values() []interface{} {
 
 // String returns a string representation of container
 func (set *Set) String() string {
-	str := "HashSet\n"
+	str := "{"
 	items := []string{}
 	for k := range set.items {
-		items = append(items, fmt.Sprintf("%v", k))
+		items = append(items, fmt.Sprintf("%#v", k))
 	}
-	str += strings.Join(items, ", ")
+	str += strings.Join(items, ", ") + "}"
 	return str
 }

--- a/sets/treeset/treeset.go
+++ b/sets/treeset/treeset.go
@@ -11,10 +11,11 @@ package treeset
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/sets"
 	rbt "github.com/emirpasic/gods/trees/redblacktree"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertSetImplementation() {
@@ -91,11 +92,11 @@ func (set *Set) Values() []interface{} {
 
 // String returns a string representation of container
 func (set *Set) String() string {
-	str := "TreeSet\n"
+	str := "{"
 	items := []string{}
 	for _, v := range set.tree.Keys() {
-		items = append(items, fmt.Sprintf("%v", v))
+		items = append(items, fmt.Sprintf("%#v", v))
 	}
-	str += strings.Join(items, ", ")
+	str += strings.Join(items, ", ") + "}"
 	return str
 }

--- a/stacks/arraystack/arraystack.go
+++ b/stacks/arraystack/arraystack.go
@@ -11,9 +11,10 @@ package arraystack
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists/arraylist"
 	"github.com/emirpasic/gods/stacks"
-	"strings"
 )
 
 func assertStackImplementation() {
@@ -76,12 +77,12 @@ func (stack *Stack) Values() []interface{} {
 
 // String returns a string representation of container
 func (stack *Stack) String() string {
-	str := "ArrayStack\n"
+	str := "["
 	values := []string{}
 	for _, value := range stack.list.Values() {
-		values = append(values, fmt.Sprintf("%v", value))
+		values = append(values, fmt.Sprintf("%#v", value))
 	}
-	str += strings.Join(values, ", ")
+	str += strings.Join(values, " ") + "]"
 	return str
 }
 

--- a/stacks/linkedliststack/linkedliststack.go
+++ b/stacks/linkedliststack/linkedliststack.go
@@ -11,9 +11,10 @@ package linkedliststack
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists/singlylinkedlist"
 	"github.com/emirpasic/gods/stacks"
-	"strings"
 )
 
 func assertStackImplementation() {
@@ -71,12 +72,12 @@ func (stack *Stack) Values() []interface{} {
 
 // String returns a string representation of container
 func (stack *Stack) String() string {
-	str := "LinkedListStack\n"
+	str := "["
 	values := []string{}
 	for _, value := range stack.list.Values() {
-		values = append(values, fmt.Sprintf("%v", value))
+		values = append(values, fmt.Sprintf("%#v", value))
 	}
-	str += strings.Join(values, ", ")
+	str += strings.Join(values, " ") + "]"
 	return str
 }
 

--- a/trees/avltree/avltree.go
+++ b/trees/avltree/avltree.go
@@ -11,6 +11,7 @@ package avltree
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/trees"
 	"github.com/emirpasic/gods/utils"
 )
@@ -189,7 +190,7 @@ func (t *Tree) Clear() {
 
 // String returns a string representation of container
 func (t *Tree) String() string {
-	str := "AVLTree\n"
+	str := ""
 	if !t.Empty() {
 		output(t.Root, "", true, &str)
 	}
@@ -197,7 +198,7 @@ func (t *Tree) String() string {
 }
 
 func (n *Node) String() string {
-	return fmt.Sprintf("%v", n.Key)
+	return fmt.Sprintf("%#v", n.Key)
 }
 
 func (t *Tree) put(key interface{}, value interface{}, p *Node, qp **Node) bool {

--- a/trees/binaryheap/binaryheap.go
+++ b/trees/binaryheap/binaryheap.go
@@ -13,10 +13,11 @@ package binaryheap
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/lists/arraylist"
 	"github.com/emirpasic/gods/trees"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertTreeImplementation() {
@@ -103,12 +104,12 @@ func (heap *Heap) Values() []interface{} {
 
 // String returns a string representation of container
 func (heap *Heap) String() string {
-	str := "BinaryHeap\n"
+	str := "<"
 	values := []string{}
 	for _, value := range heap.list.Values() {
-		values = append(values, fmt.Sprintf("%v", value))
+		values = append(values, fmt.Sprintf("%#v", value))
 	}
-	str += strings.Join(values, ", ")
+	str += strings.Join(values, " ") + ">"
 	return str
 }
 

--- a/trees/btree/btree.go
+++ b/trees/btree/btree.go
@@ -19,9 +19,10 @@ package btree
 import (
 	"bytes"
 	"fmt"
+	"strings"
+
 	"github.com/emirpasic/gods/trees"
 	"github.com/emirpasic/gods/utils"
-	"strings"
 )
 
 func assertTreeImplementation() {
@@ -191,8 +192,6 @@ func (tree *Tree) RightValue() interface{} {
 // String returns a string representation of container (for debugging purposes)
 func (tree *Tree) String() string {
 	var buffer bytes.Buffer
-	if _, err := buffer.WriteString("BTree\n"); err != nil {
-	}
 	if !tree.Empty() {
 		tree.output(&buffer, tree.Root, 0, true)
 	}
@@ -200,7 +199,7 @@ func (tree *Tree) String() string {
 }
 
 func (entry *Entry) String() string {
-	return fmt.Sprintf("%v", entry.Key)
+	return fmt.Sprintf("%#v", entry.Key)
 }
 
 func (tree *Tree) output(buffer *bytes.Buffer, node *Node, level int, isTail bool) {
@@ -211,7 +210,7 @@ func (tree *Tree) output(buffer *bytes.Buffer, node *Node, level int, isTail boo
 		if e < len(node.Entries) {
 			if _, err := buffer.WriteString(strings.Repeat("    ", level)); err != nil {
 			}
-			if _, err := buffer.WriteString(fmt.Sprintf("%v", node.Entries[e].Key) + "\n"); err != nil {
+			if _, err := buffer.WriteString(fmt.Sprintf("%#v", node.Entries[e].Key) + "\n"); err != nil {
 			}
 		}
 	}

--- a/trees/redblacktree/redblacktree.go
+++ b/trees/redblacktree/redblacktree.go
@@ -13,6 +13,7 @@ package redblacktree
 
 import (
 	"fmt"
+
 	"github.com/emirpasic/gods/trees"
 	"github.com/emirpasic/gods/utils"
 )
@@ -261,7 +262,7 @@ func (tree *Tree) Clear() {
 
 // String returns a string representation of container
 func (tree *Tree) String() string {
-	str := "RedBlackTree\n"
+	str := ""
 	if !tree.Empty() {
 		output(tree.Root, "", true, &str)
 	}
@@ -269,7 +270,7 @@ func (tree *Tree) String() string {
 }
 
 func (node *Node) String() string {
-	return fmt.Sprintf("%v", node.Key)
+	return fmt.Sprintf("%#v", node.Key)
 }
 
 func output(node *Node, prefix string, isTail bool, str *string) {


### PR DESCRIPTION
Hi, I have modified all the `String()` functions so they better represent the data they hold.

All String functions now properly use `%#v` to format keys & elements.

> This allows display not to be broken with strings with escaped characters

All String function are no longer split in two lines:

```
ArrayList
1 2 3
```

is past now. (for the better!)

**Motivation**:
The motivation for this PR was that the existing String functions give a poor display of the data structures hold, break the logging flow (new lines ??) and felt more like **demonstration-implementations** which isn't the intent of this repository.

**Logic**:
* `[x, y, z]` with comma separated elements represents a list
* `[x y z]` with spaced elements represents a stack
* `{k: v, kk: vv}` with comma separated `key: value` pairs represents any kind of map
* `{x y z}` with comma separated elements represents a set
* `<x y z>` with space separated elements represents a heap

Trees have not been further modified (beyond `%#v` value display).