### PR TITLE
utils: remove excessive type assertions

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -16,31 +16,31 @@ import (
 
 // ToString converts a value to string.
 func ToString(value interface{}) string {
-	switch value.(type) {
+	switch value := value.(type) {
 	case string:
-		return value.(string)
+		return value
 	case int8:
-		return strconv.FormatInt(int64(value.(int8)), 10)
+		return strconv.FormatInt(int64(value), 10)
 	case int16:
-		return strconv.FormatInt(int64(value.(int16)), 10)
+		return strconv.FormatInt(int64(value), 10)
 	case int32:
-		return strconv.FormatInt(int64(value.(int32)), 10)
+		return strconv.FormatInt(int64(value), 10)
 	case int64:
-		return strconv.FormatInt(int64(value.(int64)), 10)
+		return strconv.FormatInt(int64(value), 10)
 	case uint8:
-		return strconv.FormatUint(uint64(value.(uint8)), 10)
+		return strconv.FormatUint(uint64(value), 10)
 	case uint16:
-		return strconv.FormatUint(uint64(value.(uint16)), 10)
+		return strconv.FormatUint(uint64(value), 10)
 	case uint32:
-		return strconv.FormatUint(uint64(value.(uint32)), 10)
+		return strconv.FormatUint(uint64(value), 10)
 	case uint64:
-		return strconv.FormatUint(uint64(value.(uint64)), 10)
+		return strconv.FormatUint(uint64(value), 10)
 	case float32:
-		return strconv.FormatFloat(float64(value.(float32)), 'g', -1, 64)
+		return strconv.FormatFloat(float64(value), 'g', -1, 64)
 	case float64:
-		return strconv.FormatFloat(float64(value.(float64)), 'g', -1, 64)
+		return strconv.FormatFloat(float64(value), 'g', -1, 64)
 	case bool:
-		return strconv.FormatBool(value.(bool))
+		return strconv.FormatBool(value)
 	default:
 		return fmt.Sprintf("%+v", value)
 	}


### PR DESCRIPTION
Assign type switch variable to get properly-typed value
inside case clauses.

Signed-off-by: Iskander Sharipov <quasilyte@gmail.com>

Note that it's impossible to combine case lists even though some case bodies look identical.
Every case clause has a different static type of `value`, so they're incompatible.