### PR TITLE
fix arraylist remove function bug

### DIFF
--- a/lists/arraylist/arraylist.go
+++ b/lists/arraylist/arraylist.go
@@ -69,7 +69,7 @@ func (list *List) Remove(index int) {
 	}
 
 	list.elements[index] = nil                                    // cleanup reference
-	copy(list.elements[index:], list.elements[index+1:list.size]) // shift to the left by one (slow operation, need ways to optimize this)
+	copy(list.elements[:index], list.elements[index+1:list.size]) // shift to the left by one (slow operation, need ways to optimize this)
 	list.size--
 
 	list.shrink()


### PR DESCRIPTION
There is a bug which should never exist when remove element from arraylist. I found and fix it.