### PR TITLE
implements the Marshaler interface(encoding/json)

### DIFF
--- a/sets/hashset/serialization.go
+++ b/sets/hashset/serialization.go
@@ -19,6 +19,11 @@ func (set *Set) ToJSON() ([]byte, error) {
 	return json.Marshal(set.Values())
 }
 
+// ToJSON outputs the JSON representation of the set.
+func (set *Set)MarshalJSON() ([]byte, error) {
+  return json.Marshal(set.Values())
+}
+
 // FromJSON populates the set from the input JSON representation.
 func (set *Set) FromJSON(data []byte) error {
 	elements := []interface{}{}


### PR DESCRIPTION
When json.Marshal() wich is in the package "encoding/json" is called to serialize the hashset.Set type object, it will be automatically serialized, If hashset.Set implements the Marshal interface


below is the link to the document of "encoding/json"
https://golang.org/pkg/encoding/json/