### PR TITLE
Speed up removal from a set

### DIFF
--- a/lists/doublylinkedlist/doublylinkedlist.go
+++ b/lists/doublylinkedlist/doublylinkedlist.go
@@ -142,6 +142,29 @@ func (list *List) Remove(index int) {
 	list.size--
 }
 
+// Filter only keeps element for which hook returns true.
+func (list *List) Filter(hook func(value interface{}) bool) {
+
+	for element := list.first; element != nil; element = element.next {
+		if !hook(element.value) {
+			if element == list.first {
+				list.first = element.next
+			}
+			if element == list.last {
+				list.last = element.prev
+			}
+			if element.prev != nil {
+				element.prev.next = element.next
+			}
+			if element.next != nil {
+				element.next.prev = element.prev
+			}
+			list.size--
+		}
+	}
+	
+}
+
 // Contains check if values (one or more) are present in the set.
 // All values have to be present in the set for the method to return true.
 // Performance time complexity of n^2.

--- a/lists/doublylinkedlist/doublylinkedlist_test.go
+++ b/lists/doublylinkedlist/doublylinkedlist_test.go
@@ -71,6 +71,22 @@ func TestListRemove(t *testing.T) {
 	}
 }
 
+func TestListFilter(t *testing.T) {
+	list := New()
+	list.Add("a")
+	list.Add("b", "c", "d", "e", "f")
+	list.Filter(func(v interface{}) bool { return v == "b" || v == "d" })
+	if actualValue, ok := list.Get(0); actualValue != "b" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "b")
+	}
+	if actualValue, ok := list.Get(1); actualValue != "d" || !ok {
+		t.Errorf("Got %v expected %v", actualValue, "d")
+	}
+	if actualValue := list.Size(); actualValue != 2 {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+}
+
 func TestListGet(t *testing.T) {
 	list := New()
 	list.Add("a")

--- a/sets/linkedhashset/linkedhashset.go
+++ b/sets/linkedhashset/linkedhashset.go
@@ -56,15 +56,15 @@ func (set *Set) Add(items ...interface{}) {
 }
 
 // Remove removes the items (one or more) from the set.
-// Slow operation, worst-case O(n^2).
 func (set *Set) Remove(items ...interface{}) {
 	for _, item := range items {
-		if _, contains := set.table[item]; contains {
-			delete(set.table, item)
-			index := set.ordering.IndexOf(item)
-			set.ordering.Remove(index)
-		}
+		delete(set.table, item)
 	}
+	// Only keep non-deleted items
+	set.ordering.Filter(func(item interface{}) bool {
+		_, contains := set.table[item]
+		return contains
+	})
 }
 
 // Contains check if items (one or more) are present in the set.


### PR DESCRIPTION
Introduce a new Filter() command to doubly linked lists that can perform several removals in a single O(n) sweep, and use that new method to make set removal O(n) instead of O(n**2)