### PR TITLE
convert to a Go module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/emirpasic/gods
+
+go 1.13


### PR DESCRIPTION
This PR add a go.mod file in order to convert this library to a module. 

Since the library is already tagged and still in major v1 this should be enough.

The step I followed are according to the official guide https://blog.golang.org/migrating-to-go-modules:

1. go mod init github.com/emirpasic/gods
2. go mod tidy