### PR TITLE
Implement json.Marshaler and json.Unmarshaler interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1297,7 +1297,7 @@ Typical usage for key-value structures:
 package main
 
 import (
-    "encoding/json"
+	"encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/maps/hashmap"
 )
@@ -1320,7 +1320,7 @@ Typical usage for value-only structures:
 package main
 
 import (
-    "encoding/json"
+	"encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/lists/arraylist"
 )
@@ -1346,7 +1346,7 @@ Typical usage for key-value structures:
 package main
 
 import (
-    "encoding/json"
+	"encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/maps/hashmap"
 )
@@ -1368,7 +1368,7 @@ Typical usage for value-only structures:
 package main
 
 import (
-    "encoding/json"
+	"encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/lists/arraylist"
 )

--- a/README.md
+++ b/README.md
@@ -1297,6 +1297,7 @@ Typical usage for key-value structures:
 package main
 
 import (
+    "encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/maps/hashmap"
 )
@@ -1307,17 +1308,11 @@ func main() {
 	m.Put("b", "2")
 	m.Put("c", "3")
 
-	json, err := m.ToJSON()
+	jsonBytes, err := json.Marshall(m)
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Println(string(json)) // {"a":"1","b":"2","c":"3"}
-
-	json, err = json.Marshall(m)
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Println(string(json)) // {"a":"1","b":"2","c":"3"}
+	fmt.Println(string(jsonBytes)) // {"a":"1","b":"2","c":"3"}
 ```
 
 Typical usage for value-only structures:
@@ -1325,6 +1320,7 @@ Typical usage for value-only structures:
 package main
 
 import (
+    "encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/lists/arraylist"
 )
@@ -1333,17 +1329,11 @@ func main() {
 	list := arraylist.New()
 	list.Add("a", "b", "c")
 
-	json, err := list.ToJSON()
+	jsonBytes, err := json.Marshall(list)
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Println(string(json)) // ["a","b","c"]
-
-	json, err = json.Marshall(list)
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Println(string(json)) // ["a","b","c"]
+	fmt.Println(string(jsonBytes)) // ["a","b","c"]
 }
 ```
 
@@ -1356,6 +1346,7 @@ Typical usage for key-value structures:
 package main
 
 import (
+    "encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/maps/hashmap"
 )
@@ -1363,14 +1354,8 @@ import (
 func main() {
 	hm := hashmap.New()
 
-	json := []byte(`{"a":"1","b":"2"}`)
-	err := hm.FromJSON(json)
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Println(hm) // HashMap map[b:2 a:1]
-
-	err := json.Unmarshal(json, hm)
+	jsonBytes := []byte(`{"a":"1","b":"2"}`)
+	err := json.Unmarshal(jsonBytes, hm)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -1383,6 +1368,7 @@ Typical usage for value-only structures:
 package main
 
 import (
+    "encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/lists/arraylist"
 )
@@ -1390,14 +1376,8 @@ import (
 func main() {
 	list := arraylist.New()
 
-	json := []byte(`["a","b"]`)
-	err := list.FromJSON(json)
-	if err != nil {
-		fmt.Println(err)
-	}
-	fmt.Println(list) // ArrayList ["a","b"]
-
-	err := json.Unmarshal(json, list)
+	jsonBytes := []byte(`["a","b"]`)
+	err := json.Unmarshal(jsonBytes, list)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/README.md
+++ b/README.md
@@ -1312,6 +1312,12 @@ func main() {
 		fmt.Println(err)
 	}
 	fmt.Println(string(json)) // {"a":"1","b":"2","c":"3"}
+
+	json, err = json.Marshall(m)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(json)) // {"a":"1","b":"2","c":"3"}
 ```
 
 Typical usage for value-only structures:
@@ -1328,6 +1334,12 @@ func main() {
 	list.Add("a", "b", "c")
 
 	json, err := list.ToJSON()
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(string(json)) // ["a","b","c"]
+
+	json, err = json.Marshall(list)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -1357,6 +1369,12 @@ func main() {
 		fmt.Println(err)
 	}
 	fmt.Println(hm) // HashMap map[b:2 a:1]
+
+	err := json.Unmarshal(json, hm)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(hm) // HashMap map[b:2 a:1]
 }
 ```
 
@@ -1374,6 +1392,12 @@ func main() {
 
 	json := []byte(`["a","b"]`)
 	err := list.FromJSON(json)
+	if err != nil {
+		fmt.Println(err)
+	}
+	fmt.Println(list) // ArrayList ["a","b"]
+
+	err := json.Unmarshal(json, list)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/examples/serialization/serialization.go
+++ b/examples/serialization/serialization.go
@@ -1,6 +1,7 @@
 package serialization
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/lists/arraylist"
 	"github.com/emirpasic/gods/maps/hashmap"
@@ -12,15 +13,15 @@ func ListSerializationExample() {
 	list.Add("a", "b", "c")
 
 	// Serialization (marshalling)
-	json, err := list.ToJSON()
+	jsonBytes, err := json.Marshal(list)
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Println(string(json)) // ["a","b","c"]
+	fmt.Println(string(jsonBytes)) // ["a","b","c"]
 
 	// Deserialization (unmarshalling)
-	json = []byte(`["a","b"]`)
-	err = list.FromJSON(json)
+	jsonBytes = []byte(`["a","b"]`)
+	err = json.Unmarshal(jsonBytes, list)
 	if err != nil {
 		fmt.Println(err)
 	}
@@ -35,15 +36,15 @@ func MapSerializationExample() {
 	m.Put("c", "3")
 
 	// Serialization (marshalling)
-	json, err := m.ToJSON()
+	jsonBytes, err := json.Marshal(m)
 	if err != nil {
 		fmt.Println(err)
 	}
-	fmt.Println(string(json)) // {"a":"1","b":"2","c":"3"}
+	fmt.Println(string(jsonBytes)) // {"a":"1","b":"2","c":"3"}
 
 	// Deserialization (unmarshalling)
-	json = []byte(`{"a":"1","b":"2"}`)
-	err = m.FromJSON(json)
+	jsonBytes = []byte(`{"a":"1","b":"2"}`)
+	err = json.Unmarshal(jsonBytes, m)
 	if err != nil {
 		fmt.Println(err)
 	}

--- a/lists/arraylist/arraylist_test.go
+++ b/lists/arraylist/arraylist_test.go
@@ -5,6 +5,7 @@
 package arraylist
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/utils"
 	"testing"
@@ -519,10 +520,10 @@ func TestListSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := list.ToJSON()
+	jsonBytes, err := json.Marshal(list)
 	assert()
 
-	err = list.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, list)
 	assert()
 }
 

--- a/lists/arraylist/serialization.go
+++ b/lists/arraylist/serialization.go
@@ -27,3 +27,13 @@ func (list *List) FromJSON(data []byte) error {
 	}
 	return err
 }
+
+// Implements json.Marshaler inerface
+func (list *List) MarshalJSON() ([]byte, error) {
+	return list.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (list *List) UnmarshalJSON(data []byte) error {
+	return list.FromJSON(data)
+}

--- a/lists/arraylist/serialization.go
+++ b/lists/arraylist/serialization.go
@@ -28,12 +28,12 @@ func (list *List) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (list *List) MarshalJSON() ([]byte, error) {
 	return list.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (list *List) UnmarshalJSON(data []byte) error {
 	return list.FromJSON(data)
 }

--- a/lists/doublylinkedlist/doublylinkedlist_test.go
+++ b/lists/doublylinkedlist/doublylinkedlist_test.go
@@ -5,6 +5,7 @@
 package doublylinkedlist
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -525,10 +526,10 @@ func TestListSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := list.ToJSON()
+	jsonBytes, err := json.Marshal(list)
 	assert()
 
-	err = list.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, list)
 	assert()
 }
 

--- a/lists/doublylinkedlist/serialization.go
+++ b/lists/doublylinkedlist/serialization.go
@@ -30,12 +30,12 @@ func (list *List) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (list *List) MarshalJSON() ([]byte, error) {
 	return list.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (list *List) UnmarshalJSON(data []byte) error {
 	return list.FromJSON(data)
 }

--- a/lists/doublylinkedlist/serialization.go
+++ b/lists/doublylinkedlist/serialization.go
@@ -29,3 +29,13 @@ func (list *List) FromJSON(data []byte) error {
 	}
 	return err
 }
+
+// Implements json.Marshaler inerface
+func (list *List) MarshalJSON() ([]byte, error) {
+	return list.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (list *List) UnmarshalJSON(data []byte) error {
+	return list.FromJSON(data)
+}

--- a/lists/singlylinkedlist/serialization.go
+++ b/lists/singlylinkedlist/serialization.go
@@ -30,12 +30,12 @@ func (list *List) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (list *List) MarshalJSON() ([]byte, error) {
 	return list.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (list *List) UnmarshalJSON(data []byte) error {
 	return list.FromJSON(data)
 }

--- a/lists/singlylinkedlist/serialization.go
+++ b/lists/singlylinkedlist/serialization.go
@@ -29,3 +29,13 @@ func (list *List) FromJSON(data []byte) error {
 	}
 	return err
 }
+
+// Implements json.Marshaler inerface
+func (list *List) MarshalJSON() ([]byte, error) {
+	return list.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (list *List) UnmarshalJSON(data []byte) error {
+	return list.FromJSON(data)
+}

--- a/lists/singlylinkedlist/singlylinkedlist_test.go
+++ b/lists/singlylinkedlist/singlylinkedlist_test.go
@@ -5,6 +5,7 @@
 package singlylinkedlist
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 
@@ -439,10 +440,10 @@ func TestListSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := list.ToJSON()
+	jsonBytes, err := json.Marshal(list)
 	assert()
 
-	err = list.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, list)
 	assert()
 }
 

--- a/maps/hashbidimap/hashbidimap_test.go
+++ b/maps/hashbidimap/hashbidimap_test.go
@@ -5,6 +5,7 @@
 package hashbidimap
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -174,10 +175,10 @@ func TestMapSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := m.ToJSON()
+	jsonBytes, err := json.Marshal(m)
 	assert()
 
-	err = m.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, m)
 	assert()
 }
 

--- a/maps/hashmap/hashmap_test.go
+++ b/maps/hashmap/hashmap_test.go
@@ -5,6 +5,7 @@
 package hashmap
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -142,10 +143,10 @@ func TestMapSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := m.ToJSON()
+	jsonBytes, err := json.Marshal(m)
 	assert()
 
-	err = m.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, m)
 	assert()
 }
 

--- a/maps/hashmap/serialization.go
+++ b/maps/hashmap/serialization.go
@@ -36,3 +36,13 @@ func (m *Map) FromJSON(data []byte) error {
 	}
 	return err
 }
+
+// Implements json.Marshaler inerface
+func (m *Map) MarshalJSON() ([]byte, error) {
+	return m.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (m *Map) UnmarshalJSON(data []byte) error {
+	return m.FromJSON(data)
+}

--- a/maps/hashmap/serialization.go
+++ b/maps/hashmap/serialization.go
@@ -37,12 +37,12 @@ func (m *Map) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (m *Map) MarshalJSON() ([]byte, error) {
 	return m.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (m *Map) UnmarshalJSON(data []byte) error {
 	return m.FromJSON(data)
 }

--- a/maps/linkedhashmap/linkedhashmap_test.go
+++ b/maps/linkedhashmap/linkedhashmap_test.go
@@ -5,6 +5,7 @@
 package linkedhashmap
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -451,14 +452,14 @@ func TestMapSerialization(t *testing.T) {
 
 		assertSerialization(original, "A", t)
 
-		serialized, err := original.ToJSON()
+		serialized, err := json.Marshal(original)
 		if err != nil {
 			t.Errorf("Got error %v", err)
 		}
 		assertSerialization(original, "B", t)
 
 		deserialized := New()
-		err = deserialized.FromJSON(serialized)
+		err = json.Unmarshal(serialized, deserialized)
 		if err != nil {
 			t.Errorf("Got error %v", err)
 		}

--- a/maps/linkedhashmap/serialization.go
+++ b/maps/linkedhashmap/serialization.go
@@ -102,12 +102,12 @@ func (m *Map) FromJSON(data []byte) error {
 	return nil
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (m *Map) MarshalJSON() ([]byte, error) {
 	return m.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (m *Map) UnmarshalJSON(data []byte) error {
 	return m.FromJSON(data)
 }

--- a/maps/linkedhashmap/serialization.go
+++ b/maps/linkedhashmap/serialization.go
@@ -101,3 +101,13 @@ func (m *Map) FromJSON(data []byte) error {
 
 	return nil
 }
+
+// Implements json.Marshaler inerface
+func (m *Map) MarshalJSON() ([]byte, error) {
+	return m.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (m *Map) UnmarshalJSON(data []byte) error {
+	return m.FromJSON(data)
+}

--- a/maps/treebidimap/serialization.go
+++ b/maps/treebidimap/serialization.go
@@ -38,12 +38,12 @@ func (m *Map) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (m *Map) MarshalJSON() ([]byte, error) {
 	return m.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (m *Map) UnmarshalJSON(data []byte) error {
 	return m.FromJSON(data)
 }

--- a/maps/treebidimap/serialization.go
+++ b/maps/treebidimap/serialization.go
@@ -37,3 +37,13 @@ func (m *Map) FromJSON(data []byte) error {
 	}
 	return err
 }
+
+// Implements json.Marshaler inerface
+func (m *Map) MarshalJSON() ([]byte, error) {
+	return m.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (m *Map) UnmarshalJSON(data []byte) error {
+	return m.FromJSON(data)
+}

--- a/maps/treebidimap/treebidimap_test.go
+++ b/maps/treebidimap/treebidimap_test.go
@@ -5,6 +5,7 @@
 package treebidimap
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/emirpasic/gods/utils"
 	"testing"
@@ -484,14 +485,14 @@ func TestMapSerialization(t *testing.T) {
 
 		assertSerialization(original, "A", t)
 
-		serialized, err := original.ToJSON()
+		serialized, err := json.Marshal(original)
 		if err != nil {
 			t.Errorf("Got error %v", err)
 		}
 		assertSerialization(original, "B", t)
 
 		deserialized := NewWith(utils.StringComparator, utils.StringComparator)
-		err = deserialized.FromJSON(serialized)
+		err = json.Unmarshal(serialized, deserialized)
 		if err != nil {
 			t.Errorf("Got error %v", err)
 		}

--- a/maps/treemap/serialization.go
+++ b/maps/treemap/serialization.go
@@ -20,3 +20,13 @@ func (m *Map) ToJSON() ([]byte, error) {
 func (m *Map) FromJSON(data []byte) error {
 	return m.tree.FromJSON(data)
 }
+
+// Implements json.Marshaler inerface
+func (m *Map) MarshalJSON() ([]byte, error) {
+	return m.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (m *Map) UnmarshalJSON(data []byte) error {
+	return m.FromJSON(data)
+}

--- a/maps/treemap/serialization.go
+++ b/maps/treemap/serialization.go
@@ -21,12 +21,12 @@ func (m *Map) FromJSON(data []byte) error {
 	return m.tree.FromJSON(data)
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (m *Map) MarshalJSON() ([]byte, error) {
 	return m.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (m *Map) UnmarshalJSON(data []byte) error {
 	return m.FromJSON(data)
 }

--- a/maps/treemap/treemap_test.go
+++ b/maps/treemap/treemap_test.go
@@ -5,6 +5,7 @@
 package treemap
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -507,14 +508,14 @@ func TestMapSerialization(t *testing.T) {
 
 		assertSerialization(original, "A", t)
 
-		serialized, err := original.ToJSON()
+		serialized, err := json.Marshal(original)
 		if err != nil {
 			t.Errorf("Got error %v", err)
 		}
 		assertSerialization(original, "B", t)
 
 		deserialized := NewWithStringComparator()
-		err = deserialized.FromJSON(serialized)
+		err = json.Unmarshal(serialized, deserialized)
 		if err != nil {
 			t.Errorf("Got error %v", err)
 		}

--- a/sets/hashset/hashset_test.go
+++ b/sets/hashset/hashset_test.go
@@ -5,6 +5,7 @@
 package hashset
 
 import (
+	"encoding/json"
 	"testing"
 )
 
@@ -98,10 +99,10 @@ func TestSetSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := set.ToJSON()
+	jsonBytes, err := json.Marshal(set)
 	assert()
 
-	err = set.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, set)
 	assert()
 }
 

--- a/sets/hashset/serialization.go
+++ b/sets/hashset/serialization.go
@@ -29,3 +29,13 @@ func (set *Set) FromJSON(data []byte) error {
 	}
 	return err
 }
+
+// Implements json.Marshaler inerface
+func (set *Set) MarshalJSON() ([]byte, error) {
+	return set.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (set *Set) UnmarshalJSON(data []byte) error {
+	return set.FromJSON(data)
+}

--- a/sets/hashset/serialization.go
+++ b/sets/hashset/serialization.go
@@ -30,12 +30,12 @@ func (set *Set) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (set *Set) MarshalJSON() ([]byte, error) {
 	return set.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (set *Set) UnmarshalJSON(data []byte) error {
 	return set.FromJSON(data)
 }

--- a/sets/linkedhashset/linkedhashset_test.go
+++ b/sets/linkedhashset/linkedhashset_test.go
@@ -5,6 +5,7 @@
 package linkedhashset
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -351,10 +352,10 @@ func TestSetSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := set.ToJSON()
+	jsonBytes, err := json.Marshal(set)
 	assert()
 
-	err = set.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, set)
 	assert()
 }
 

--- a/sets/linkedhashset/serialization.go
+++ b/sets/linkedhashset/serialization.go
@@ -29,3 +29,13 @@ func (set *Set) FromJSON(data []byte) error {
 	}
 	return err
 }
+
+// Implements json.Marshaler inerface
+func (set *Set) MarshalJSON() ([]byte, error) {
+	return set.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (set *Set) UnmarshalJSON(data []byte) error {
+	return set.FromJSON(data)
+}

--- a/sets/linkedhashset/serialization.go
+++ b/sets/linkedhashset/serialization.go
@@ -30,12 +30,12 @@ func (set *Set) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (set *Set) MarshalJSON() ([]byte, error) {
 	return set.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (set *Set) UnmarshalJSON(data []byte) error {
 	return set.FromJSON(data)
 }

--- a/sets/treeset/serialization.go
+++ b/sets/treeset/serialization.go
@@ -29,3 +29,13 @@ func (set *Set) FromJSON(data []byte) error {
 	}
 	return err
 }
+
+// Implements json.Marshaler inerface
+func (set *Set) MarshalJSON() ([]byte, error) {
+	return set.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (set *Set) UnmarshalJSON(data []byte) error {
+	return set.FromJSON(data)
+}

--- a/sets/treeset/serialization.go
+++ b/sets/treeset/serialization.go
@@ -30,12 +30,12 @@ func (set *Set) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (set *Set) MarshalJSON() ([]byte, error) {
 	return set.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (set *Set) UnmarshalJSON(data []byte) error {
 	return set.FromJSON(data)
 }

--- a/sets/treeset/treeset_test.go
+++ b/sets/treeset/treeset_test.go
@@ -5,6 +5,7 @@
 package treeset
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -360,10 +361,10 @@ func TestSetSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := set.ToJSON()
+	jsonBytes, err := json.Marshal(set)
 	assert()
 
-	err = set.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, set)
 	assert()
 }
 

--- a/stacks/arraystack/arraystack_test.go
+++ b/stacks/arraystack/arraystack_test.go
@@ -5,6 +5,7 @@
 package arraystack
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -253,10 +254,10 @@ func TestStackSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := stack.ToJSON()
+	jsonBytes, err := json.Marshal(stack)
 	assert()
 
-	err = stack.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, stack)
 	assert()
 }
 

--- a/stacks/arraystack/serialization.go
+++ b/stacks/arraystack/serialization.go
@@ -21,12 +21,12 @@ func (stack *Stack) FromJSON(data []byte) error {
 	return stack.list.FromJSON(data)
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (stack *Stack) MarshalJSON() ([]byte, error) {
 	return stack.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (stack *Stack) UnmarshalJSON(data []byte) error {
 	return stack.FromJSON(data)
 }

--- a/stacks/arraystack/serialization.go
+++ b/stacks/arraystack/serialization.go
@@ -20,3 +20,13 @@ func (stack *Stack) ToJSON() ([]byte, error) {
 func (stack *Stack) FromJSON(data []byte) error {
 	return stack.list.FromJSON(data)
 }
+
+// Implements json.Marshaler inerface
+func (stack *Stack) MarshalJSON() ([]byte, error) {
+	return stack.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (stack *Stack) UnmarshalJSON(data []byte) error {
+	return stack.FromJSON(data)
+}

--- a/stacks/linkedliststack/linkedliststack_test.go
+++ b/stacks/linkedliststack/linkedliststack_test.go
@@ -5,6 +5,7 @@
 package linkedliststack
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -169,10 +170,10 @@ func TestStackSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := stack.ToJSON()
+	jsonBytes, err := json.Marshal(stack)
 	assert()
 
-	err = stack.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, stack)
 	assert()
 }
 

--- a/stacks/linkedliststack/serialization.go
+++ b/stacks/linkedliststack/serialization.go
@@ -21,12 +21,12 @@ func (stack *Stack) FromJSON(data []byte) error {
 	return stack.list.FromJSON(data)
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (stack *Stack) MarshalJSON() ([]byte, error) {
 	return stack.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (stack *Stack) UnmarshalJSON(data []byte) error {
 	return stack.FromJSON(data)
 }

--- a/stacks/linkedliststack/serialization.go
+++ b/stacks/linkedliststack/serialization.go
@@ -20,3 +20,13 @@ func (stack *Stack) ToJSON() ([]byte, error) {
 func (stack *Stack) FromJSON(data []byte) error {
 	return stack.list.FromJSON(data)
 }
+
+// Implements json.Marshaler inerface
+func (stack *Stack) MarshalJSON() ([]byte, error) {
+	return stack.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (stack *Stack) UnmarshalJSON(data []byte) error {
+	return stack.FromJSON(data)
+}

--- a/trees/avltree/avltree_test.go
+++ b/trees/avltree/avltree_test.go
@@ -4,6 +4,7 @@
 package avltree
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -580,10 +581,10 @@ func TestAVLTreeSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := tree.ToJSON()
+	jsonBytes, err := json.Marshal(tree)
 	assert()
 
-	err = tree.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, tree)
 	assert()
 }
 

--- a/trees/avltree/serialization.go
+++ b/trees/avltree/serialization.go
@@ -25,11 +25,6 @@ func (tree *Tree) ToJSON() ([]byte, error) {
 	return json.Marshal(&elements)
 }
 
-// Implements json.Marshaler inerface
-func (tree *Tree) MarshalJSON() ([]byte, error) {
-	return tree.ToJSON()
-}
-
 // FromJSON populates the tree from the input JSON representation.
 func (tree *Tree) FromJSON(data []byte) error {
 	elements := make(map[string]interface{})
@@ -41,6 +36,11 @@ func (tree *Tree) FromJSON(data []byte) error {
 		}
 	}
 	return err
+}
+
+// Implements json.Marshaler inerface
+func (tree *Tree) MarshalJSON() ([]byte, error) {
+	return tree.ToJSON()
 }
 
 // Implements json.Unmarshaler inerface

--- a/trees/avltree/serialization.go
+++ b/trees/avltree/serialization.go
@@ -25,6 +25,11 @@ func (tree *Tree) ToJSON() ([]byte, error) {
 	return json.Marshal(&elements)
 }
 
+// Implements json.Marshaler inerface
+func (tree *Tree) MarshalJSON() ([]byte, error) {
+	return tree.ToJSON()
+}
+
 // FromJSON populates the tree from the input JSON representation.
 func (tree *Tree) FromJSON(data []byte) error {
 	elements := make(map[string]interface{})
@@ -36,4 +41,9 @@ func (tree *Tree) FromJSON(data []byte) error {
 		}
 	}
 	return err
+}
+
+// Implements json.Unmarshaler inerface
+func (tree *Tree) UnmarshalJSON(data []byte) error {
+	return tree.FromJSON(data)
 }

--- a/trees/avltree/serialization.go
+++ b/trees/avltree/serialization.go
@@ -38,12 +38,12 @@ func (tree *Tree) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (tree *Tree) MarshalJSON() ([]byte, error) {
 	return tree.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (tree *Tree) UnmarshalJSON(data []byte) error {
 	return tree.FromJSON(data)
 }

--- a/trees/binaryheap/binaryheap_test.go
+++ b/trees/binaryheap/binaryheap_test.go
@@ -5,6 +5,7 @@
 package binaryheap
 
 import (
+	"encoding/json"
 	"math/rand"
 	"testing"
 )
@@ -284,10 +285,10 @@ func TestBinaryHeapSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := heap.ToJSON()
+	jsonBytes, err := json.Marshal(heap)
 	assert()
 
-	err = heap.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, heap)
 	assert()
 }
 

--- a/trees/binaryheap/serialization.go
+++ b/trees/binaryheap/serialization.go
@@ -20,3 +20,13 @@ func (heap *Heap) ToJSON() ([]byte, error) {
 func (heap *Heap) FromJSON(data []byte) error {
 	return heap.list.FromJSON(data)
 }
+
+// Implements json.Marshaler inerface
+func (tree *Tree) MarshalJSON() ([]byte, error) {
+	return tree.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (tree *Tree) UnmarshalJSON(data []byte) error {
+	return tree.FromJSON(data)
+}

--- a/trees/binaryheap/serialization.go
+++ b/trees/binaryheap/serialization.go
@@ -21,12 +21,12 @@ func (heap *Heap) FromJSON(data []byte) error {
 	return heap.list.FromJSON(data)
 }
 
-// Implements json.Marshaler inerface
-func (tree *Tree) MarshalJSON() ([]byte, error) {
-	return tree.ToJSON()
+// MarshalJSON Implements json.Marshaler inerface
+func (heap *Heap) MarshalJSON() ([]byte, error) {
+	return heap.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
-func (tree *Tree) UnmarshalJSON(data []byte) error {
-	return tree.FromJSON(data)
+// UnmarshalJSON Implements json.Unmarshaler inerface
+func (heap *Heap) UnmarshalJSON(data []byte) error {
+	return heap.FromJSON(data)
 }

--- a/trees/btree/btree_test.go
+++ b/trees/btree/btree_test.go
@@ -5,6 +5,7 @@
 package btree
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -1098,10 +1099,10 @@ func TestBTreeSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := tree.ToJSON()
+	jsonBytes, err := json.Marshal(tree)
 	assert()
 
-	err = tree.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, tree)
 	assert()
 }
 

--- a/trees/btree/serialization.go
+++ b/trees/btree/serialization.go
@@ -37,3 +37,13 @@ func (tree *Tree) FromJSON(data []byte) error {
 	}
 	return err
 }
+
+// Implements json.Marshaler inerface
+func (tree *Tree) MarshalJSON() ([]byte, error) {
+	return tree.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (tree *Tree) UnmarshalJSON(data []byte) error {
+	return tree.FromJSON(data)
+}

--- a/trees/btree/serialization.go
+++ b/trees/btree/serialization.go
@@ -38,12 +38,12 @@ func (tree *Tree) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (tree *Tree) MarshalJSON() ([]byte, error) {
 	return tree.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (tree *Tree) UnmarshalJSON(data []byte) error {
 	return tree.FromJSON(data)
 }

--- a/trees/redblacktree/redblacktree_test.go
+++ b/trees/redblacktree/redblacktree_test.go
@@ -5,6 +5,7 @@
 package redblacktree
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 )
@@ -581,10 +582,10 @@ func TestRedBlackTreeSerialization(t *testing.T) {
 
 	assert()
 
-	json, err := tree.ToJSON()
+	jsonBytes, err := json.Marshal(tree)
 	assert()
 
-	err = tree.FromJSON(json)
+	err = json.Unmarshal(jsonBytes, tree)
 	assert()
 }
 

--- a/trees/redblacktree/serialization.go
+++ b/trees/redblacktree/serialization.go
@@ -37,3 +37,13 @@ func (tree *Tree) FromJSON(data []byte) error {
 	}
 	return err
 }
+
+// Implements json.Marshaler inerface
+func (tree *Tree) MarshalJSON() ([]byte, error) {
+	return tree.ToJSON()
+}
+
+// Implements json.Unmarshaler inerface
+func (tree *Tree) UnmarshalJSON(data []byte) error {
+	return tree.FromJSON(data)
+}

--- a/trees/redblacktree/serialization.go
+++ b/trees/redblacktree/serialization.go
@@ -38,12 +38,12 @@ func (tree *Tree) FromJSON(data []byte) error {
 	return err
 }
 
-// Implements json.Marshaler inerface
+// MarshalJSON Implements json.Marshaler inerface
 func (tree *Tree) MarshalJSON() ([]byte, error) {
 	return tree.ToJSON()
 }
 
-// Implements json.Unmarshaler inerface
+// UnmarshalJSON Implements json.Unmarshaler inerface
 func (tree *Tree) UnmarshalJSON(data []byte) error {
 	return tree.FromJSON(data)
 }


### PR DESCRIPTION
# Purpose

I'd like to leverage gods nested within larger structs and still have json serialization just work.

Example:

```
type Something struct {
	Field1 string
	Field2 int
	MySet  *Set
}

set := New()
set.Add("a", "b", "c")

something := Something{"hello world", 10, set}
jsonBytes, err := json.Marshal(something)
if err != nil {
	t.Errorf("Got error %v", err)
}
fmt.Println(string(jsonBytes)) // {"Field1":"hello world","Field2":10,"MySet":["b","c","a"]}
```

The interface methods just call the existing `ToJSON` and `FromJSON` methods, so no existing users should be affected, and also keeps the testing simple.

