### PR TITLE
Simple implementation of set intersection

### DIFF
--- a/sets/hashset/hashset.go
+++ b/sets/hashset/hashset.go
@@ -97,3 +97,14 @@ func (set *Set) String() string {
 	str += strings.Join(items, ", ")
 	return str
 }
+
+// Intersection returns the intersection between two sets
+func (set *Set) Intersection(another *Set) *Set {
+	result := New()
+	for item, _ := range another.items {
+		if set.Contains(item) {
+			result.Add(item)
+		}
+	}
+	return result
+}

--- a/sets/hashset/hashset_test.go
+++ b/sets/hashset/hashset_test.go
@@ -105,6 +105,18 @@ func TestSetSerialization(t *testing.T) {
 	assert()
 }
 
+func TestSetIntersection(t *testing.T) {
+	set := New("a", "b", "c", "d")
+	anotherSet := New("c", "d", "f", "g")
+	intersection := set.Intersection(anotherSet)
+	if actualValue, expectedValue := intersection.Size(), 2; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if actualValue := set.Contains("c", "d"); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
 func benchmarkContains(b *testing.B, set *Set, size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {

--- a/sets/linkedhashset/linkedhashset.go
+++ b/sets/linkedhashset/linkedhashset.go
@@ -116,3 +116,14 @@ func (set *Set) String() string {
 	str += strings.Join(items, ", ")
 	return str
 }
+
+// Intersection returns the intersection between two sets
+func (set *Set) Intersection(another *Set) *Set {
+	result := New()
+	for item, _ := range another.table {
+		if set.Contains(item) {
+			result.Add(item)
+		}
+	}
+	return result
+}

--- a/sets/linkedhashset/linkedhashset_test.go
+++ b/sets/linkedhashset/linkedhashset_test.go
@@ -358,6 +358,18 @@ func TestSetSerialization(t *testing.T) {
 	assert()
 }
 
+func TestSetIntersection(t *testing.T) {
+	set := New("a", "b", "c", "d")
+	anotherSet := New("c", "d", "f", "g")
+	intersection := set.Intersection(anotherSet)
+	if actualValue, expectedValue := intersection.Size(), 2; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if actualValue := set.Contains("c", "d"); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
 func benchmarkContains(b *testing.B, set *Set, size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {

--- a/sets/sets.go
+++ b/sets/sets.go
@@ -16,6 +16,7 @@ type Set interface {
 	Add(elements ...interface{})
 	Remove(elements ...interface{})
 	Contains(elements ...interface{}) bool
+	Intersection(another *Set) *Set
 
 	containers.Container
 	// Empty() bool

--- a/sets/treeset/treeset.go
+++ b/sets/treeset/treeset.go
@@ -111,3 +111,14 @@ func (set *Set) String() string {
 	str += strings.Join(items, ", ")
 	return str
 }
+
+// Intersection returns the intersection between two sets
+func (set *Set) Intersection(another *Set) *Set {
+	result := NewWith(set.tree.Comparator)
+	for _, item := range another.Values() {
+		if set.Contains(item) {
+			result.Add(item)
+		}
+	}
+	return result
+}

--- a/sets/treeset/treeset_test.go
+++ b/sets/treeset/treeset_test.go
@@ -367,6 +367,18 @@ func TestSetSerialization(t *testing.T) {
 	assert()
 }
 
+func TestSetIntersection(t *testing.T) {
+	set := NewWithStringComparator("a", "b", "c", "d")
+	anotherSet := NewWithStringComparator("c", "d", "f", "g")
+	intersection := set.Intersection(anotherSet)
+	if actualValue, expectedValue := intersection.Size(), 2; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if actualValue := set.Contains("c", "d"); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
 func benchmarkContains(b *testing.B, set *Set, size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {


### PR DESCRIPTION
Simple implementation of set intersection for `hashset.Set`, `linkedhashset.Set`, and `treeset.Set`