### PR TITLE
Added Power Support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,11 @@ go:
   - 1.13.x
   - 1.14.x
   - tip
+jobs:
+ exclude:
+  - arch: ppc64le
+    go: 1.2.x
+  - arch: ppc64le
+    go: 1.3.x
+  - arch: ppc64le
+    go: 1.4.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ go:
   - 1.14.x
   - tip
 jobs:
- exclude:
+ exclude: # Excluded for power support as the lower versions are not supported
   - arch: ppc64le
     go: 1.2.x
   - arch: ppc64le

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: go
+arch:
+  - amd64
+  - ppc64le
 go:
   - 1.2.x
   - 1.3.x


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.