### PR TITLE
Added queue in both arraylist and linkedlist forms

### DIFF
--- a/lists/arraylist/arraylist.go
+++ b/lists/arraylist/arraylist.go
@@ -75,6 +75,18 @@ func (list *List) Remove(index int) {
 	list.shrink()
 }
 
+func (list *List) RemoveFirstElem() {
+
+	if !list.withinRange(0) {
+		return
+	}
+
+	list.elements = list.elements[1:]
+	list.size--
+
+	list.shrink()
+}
+
 // Contains checks if elements (one or more) are present in the set.
 // All elements have to be present in the set for the method to return true.
 // Performance time complexity of n^2.

--- a/queues/arrayqueue/arrayqueue.go
+++ b/queues/arrayqueue/arrayqueue.go
@@ -1,0 +1,78 @@
+package arrayqueue
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/emirpasic/gods/lists/arraylist"
+)
+
+// Queue holds elements in an array-list
+type Queue struct {
+	list *arraylist.List
+}
+
+// New instantiates a new empty queue
+func New() *Queue {
+	return &Queue{list: arraylist.New()}
+}
+
+// Push adds a value onto the back of the queue
+func (queue *Queue) Push(value interface{}) {
+	queue.list.Add(value)
+}
+
+// Pop removes front element in queue and returns it, or nil if queue is empty.
+// Second return parameter is true, unless the queue was empty and there was nothing to pop.
+func (queue *Queue) Pop() (value interface{}, ok bool) {
+	value, ok = queue.list.Get(0)
+	queue.list.Remove(0)
+	return
+}
+
+// Peek returns front element in the queue without removing it, or nil if queue is empty.
+// Second return parameter is true, unless the queue was empty and there was nothing to peek.
+func (queue *Queue) Peek() (value interface{}, ok bool) {
+	return queue.list.Get(0)
+}
+
+// Empty returns true if queue does not contain any elements.
+func (queue *Queue) Empty() bool {
+	return queue.list.Empty()
+}
+
+// Size returns number of elements within the queue.
+func (queue *Queue) Size() int {
+	return queue.list.Size()
+}
+
+// Clear removes all elements from the queue.
+func (queue *Queue) Clear() {
+	queue.list.Clear()
+}
+
+// Values returns all elements in the queue (FIFO order).
+func (queue *Queue) Values() []interface{} {
+	size := queue.list.Size()
+	elements := make([]interface{}, size, size)
+	for i := 0; i < size; i++ {
+		elements[i], _ = queue.list.Get(i) // FIFO
+	}
+	return elements
+}
+
+// String returns a string representation of container
+func (queue *Queue) String() string {
+	str := "ArrayQueue\n"
+	values := []string{}
+	for _, value := range queue.list.Values() {
+		values = append(values, fmt.Sprintf("%v", value))
+	}
+	str += strings.Join(values, ", ")
+	return str
+}
+
+// Check that the index is within bounds of the list
+func (queue *Queue) withinRange(index int) bool {
+	return index >= 0 && index < queue.list.Size()
+}

--- a/queues/arrayqueue/arrayqueue.go
+++ b/queues/arrayqueue/arrayqueue.go
@@ -26,7 +26,7 @@ func (queue *Queue) Push(value interface{}) {
 // Second return parameter is true, unless the queue was empty and there was nothing to pop.
 func (queue *Queue) Pop() (value interface{}, ok bool) {
 	value, ok = queue.list.Get(0)
-	queue.list.Remove(0)
+	queue.list.RemoveFirstElem()
 	return
 }
 

--- a/queues/arrayqueue/arrayqueue_test.go
+++ b/queues/arrayqueue/arrayqueue_test.go
@@ -1,0 +1,358 @@
+package arrayqueue
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestQueuePush(t *testing.T) {
+	queue := New()
+	if actualValue := queue.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	queue.Push(1)
+	queue.Push(2)
+	queue.Push(3)
+
+	if actualValue := queue.Values(); actualValue[0].(int) != 1 || actualValue[1].(int) != 2 || actualValue[2].(int) != 3 {
+		t.Errorf("Got %v expected %v", actualValue, "[1,2,3]")
+	}
+	if actualValue := queue.Empty(); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+	if actualValue := queue.Size(); actualValue != 3 {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+	if actualValue, ok := queue.Peek(); actualValue != 1 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+}
+
+func TestQueuePeek(t *testing.T) {
+	queue := New()
+	if actualValue, ok := queue.Peek(); actualValue != nil || ok {
+		t.Errorf("Got %v expected %v", actualValue, nil)
+	}
+	queue.Push(1)
+	queue.Push(2)
+	queue.Push(3)
+	if actualValue, ok := queue.Peek(); actualValue != 1 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 1)
+	}
+}
+
+func TestQueuePop(t *testing.T) {
+	queue := New()
+	queue.Push(1)
+	queue.Push(2)
+	queue.Push(3)
+	queue.Pop()
+	if actualValue, ok := queue.Peek(); actualValue != 2 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	if actualValue, ok := queue.Pop(); actualValue != 2 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	if actualValue, ok := queue.Pop(); actualValue != 3 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+	if actualValue, ok := queue.Pop(); actualValue != nil || ok {
+		t.Errorf("Got %v expected %v", actualValue, nil)
+	}
+	if actualValue := queue.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := queue.Values(); len(actualValue) != 0 {
+		t.Errorf("Got %v expected %v", actualValue, "[]")
+	}
+}
+
+func TestQueueIteratorOnEmpty(t *testing.T) {
+	queue := New()
+	it := queue.Iterator()
+	for it.Next() {
+		t.Errorf("Shouldn't iterate on empty queue")
+	}
+}
+
+func TestQueueIteratorNext(t *testing.T) {
+	queue := New()
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+
+	it := queue.Iterator()
+	count := 0
+	for it.Next() {
+		count++
+		index := it.Index()
+		value := it.Value()
+		switch index {
+		case 0:
+			if actualValue, expectedValue := value, "a"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		case 1:
+			if actualValue, expectedValue := value, "b"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		case 2:
+			if actualValue, expectedValue := value, "c"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		default:
+			t.Errorf("Too many")
+		}
+		if actualValue, expectedValue := index, count-1; actualValue != expectedValue {
+			t.Errorf("Got %v expected %v", actualValue, expectedValue)
+		}
+	}
+	if actualValue, expectedValue := count, 3; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+}
+
+func TestQueueIteratorPrev(t *testing.T) {
+	queue := New()
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+
+	it := queue.Iterator()
+	for it.Next() {
+	}
+	count := 0
+	for it.Prev() {
+		count++
+		index := it.Index()
+		value := it.Value()
+		switch index {
+		case 0:
+			if actualValue, expectedValue := value, "a"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		case 1:
+			if actualValue, expectedValue := value, "b"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		case 2:
+			if actualValue, expectedValue := value, "c"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		default:
+			t.Errorf("Too many")
+		}
+		if actualValue, expectedValue := index, 3-count; actualValue != expectedValue {
+			t.Errorf("Got %v expected %v", actualValue, expectedValue)
+		}
+	}
+	if actualValue, expectedValue := count, 3; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+}
+
+func TestQueueIteratorBegin(t *testing.T) {
+	queue := New()
+	it := queue.Iterator()
+	it.Begin()
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+	for it.Next() {
+	}
+	it.Begin()
+	it.Next()
+	if index, value := it.Index(), it.Value(); index != 0 || value != "a" {
+		t.Errorf("Got %v,%v expected %v,%v", index, value, 0, "a")
+	}
+}
+
+func TestQueueIteratorEnd(t *testing.T) {
+	queue := New()
+	it := queue.Iterator()
+
+	if index := it.Index(); index != -1 {
+		t.Errorf("Got %v expected %v", index, -1)
+	}
+
+	it.End()
+	if index := it.Index(); index != 0 {
+		t.Errorf("Got %v expected %v", index, 0)
+	}
+
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+	it.End()
+	if index := it.Index(); index != queue.Size() {
+		t.Errorf("Got %v expected %v", index, queue.Size())
+	}
+
+	it.Prev()
+	if index, value := it.Index(), it.Value(); index != queue.Size()-1 || value != "c" {
+		t.Errorf("Got %v,%v expected %v,%v", index, value, queue.Size()-1, "c")
+	}
+}
+
+func TestQueueIteratorFirst(t *testing.T) {
+	queue := New()
+	it := queue.Iterator()
+	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+	if actualValue, expectedValue := it.First(), true; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if index, value := it.Index(), it.Value(); index != 0 || value != "a" {
+		t.Errorf("Got %v,%v expected %v,%v", index, value, 0, "a")
+	}
+}
+
+func TestQueueIteratorLast(t *testing.T) {
+	queue := New()
+	it := queue.Iterator()
+	if actualValue, expectedValue := it.Last(), false; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+	if actualValue, expectedValue := it.Last(), true; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if index, value := it.Index(), it.Value(); index != 2 || value != "c" {
+		t.Errorf("Got %v,%v expected %v,%v", index, value, 2, "c")
+	}
+}
+
+func TestQueueSerialization(t *testing.T) {
+	queue := New()
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+
+	var err error
+	assert := func() {
+		if actualValue, expectedValue := fmt.Sprintf("%s%s%s", queue.Values()...), "abc"; actualValue != expectedValue {
+			t.Errorf("Got %v expected %v", actualValue, expectedValue)
+		}
+		if actualValue, expectedValue := queue.Size(), 3; actualValue != expectedValue {
+			t.Errorf("Got %v expected %v", actualValue, expectedValue)
+		}
+		if err != nil {
+			t.Errorf("Got error %v", err)
+		}
+	}
+
+	assert()
+
+	json, err := queue.ToJSON()
+	assert()
+
+	err = queue.FromJSON(json)
+	assert()
+}
+
+func benchmarkPush(b *testing.B, queue *Queue, size int) {
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < size; n++ {
+			queue.Push(n)
+		}
+	}
+}
+
+func benchmarkPop(b *testing.B, queue *Queue, size int) {
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < size; n++ {
+			queue.Pop()
+		}
+	}
+}
+
+func BenchmarkArrayQueuePop100(b *testing.B) {
+	b.StopTimer()
+	size := 100
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPop(b, queue, size)
+}
+
+func BenchmarkArrayQueuePop1000(b *testing.B) {
+	b.StopTimer()
+	size := 1000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPop(b, queue, size)
+}
+
+func BenchmarkArrayQueuePop10000(b *testing.B) {
+	b.StopTimer()
+	size := 10000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPop(b, queue, size)
+}
+
+func BenchmarkArrayQueuePop100000(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPop(b, queue, size)
+}
+
+func BenchmarkArrayQueuePush100(b *testing.B) {
+	b.StopTimer()
+	size := 100
+	queue := New()
+	b.StartTimer()
+	benchmarkPush(b, queue, size)
+}
+
+func BenchmarkArrayQueuePush1000(b *testing.B) {
+	b.StopTimer()
+	size := 1000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPush(b, queue, size)
+}
+
+func BenchmarkArrayQueuePush10000(b *testing.B) {
+	b.StopTimer()
+	size := 10000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPush(b, queue, size)
+}
+
+func BenchmarkArrayQueuePush100000(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPush(b, queue, size)
+}

--- a/queues/arrayqueue/iterator.go
+++ b/queues/arrayqueue/iterator.go
@@ -1,0 +1,80 @@
+package arrayqueue
+
+import "github.com/emirpasic/gods/containers"
+
+func assertIteratorImplementation() {
+	var _ containers.ReverseIteratorWithIndex = (*Iterator)(nil)
+}
+
+// Iterator returns a stateful iterator whose values can be fetched by an index.
+type Iterator struct {
+	queue *Queue
+	index int
+}
+
+// Iterator returns a stateful iterator whose values can be fetched by an index.
+func (queue *Queue) Iterator() Iterator {
+	return Iterator{queue: queue, index: -1}
+}
+
+// Next moves the iterator to the next element and returns true if there was a next element in the container.
+// If Next() returns true, then next element's index and value can be retrieved by Index() and Value().
+// If Next() was called for the first time, then it will point the iterator to the first element if it exists.
+// Modifies the state of the iterator.
+func (iterator *Iterator) Next() bool {
+	if iterator.index < iterator.queue.Size() {
+		iterator.index++
+	}
+	return iterator.queue.withinRange(iterator.index)
+}
+
+// Prev moves the iterator to the previous element and returns true if there was a previous element in the container.
+// If Prev() returns true, then previous element's index and value can be retrieved by Index() and Value().
+// Modifies the state of the iterator.
+func (iterator *Iterator) Prev() bool {
+	if iterator.index >= 0 {
+		iterator.index--
+	}
+	return iterator.queue.withinRange(iterator.index)
+}
+
+// Value returns the current element's value.
+// Does not modify the state of the iterator.
+func (iterator *Iterator) Value() interface{} {
+	value, _ := iterator.queue.list.Get(iterator.index) // FIFO
+	return value
+}
+
+// Index returns the current element's index.
+// Does not modify the state of the iterator.
+func (iterator *Iterator) Index() int {
+	return iterator.index
+}
+
+// Begin resets the iterator to its initial state (one-before-first)
+// Call Next() to fetch the first element if any.
+func (iterator *Iterator) Begin() {
+	iterator.index = -1
+}
+
+// End moves the iterator past the last element (one-past-the-end).
+// Call Prev() to fetch the last element if any.
+func (iterator *Iterator) End() {
+	iterator.index = iterator.queue.Size()
+}
+
+// First moves the iterator to the first element and returns true if there was a first element in the container.
+// If First() returns true, then first element's index and value can be retrieved by Index() and Value().
+// Modifies the state of the iterator.
+func (iterator *Iterator) First() bool {
+	iterator.Begin()
+	return iterator.Next()
+}
+
+// Last moves the iterator to the last element and returns true if there was a last element in the container.
+// If Last() returns true, then last element's index and value can be retrieved by Index() and Value().
+// Modifies the state of the iterator.
+func (iterator *Iterator) Last() bool {
+	iterator.End()
+	return iterator.Prev()
+}

--- a/queues/arrayqueue/serialization.go
+++ b/queues/arrayqueue/serialization.go
@@ -1,0 +1,18 @@
+package arrayqueue
+
+import "github.com/emirpasic/gods/containers"
+
+func assertSerializationImplementation() {
+	var _ containers.JSONSerializer = (*Queue)(nil)
+	var _ containers.JSONDeserializer = (*Queue)(nil)
+}
+
+// ToJSON outputs the JSON representation of the queue.
+func (queue *Queue) ToJSON() ([]byte, error) {
+	return queue.list.ToJSON()
+}
+
+// FromJSON populates the queue from the input JSON representation.
+func (queue *Queue) FromJSON(data []byte) error {
+	return queue.list.FromJSON(data)
+}

--- a/queues/linkedlistqueue/iterator.go
+++ b/queues/linkedlistqueue/iterator.go
@@ -1,0 +1,56 @@
+package linkedlistqueue
+
+import "github.com/emirpasic/gods/containers"
+
+func assertIteratorImplementation() {
+	var _ containers.IteratorWithIndex = (*Iterator)(nil)
+}
+
+// Iterator returns a stateful iterator whose values can be fetched by an index.
+type Iterator struct {
+	queue *Queue
+	index int
+}
+
+// Iterator returns a stateful iterator whose values can be fetched by an index.
+func (queue *Queue) Iterator() Iterator {
+	return Iterator{queue: queue, index: -1}
+}
+
+// Next moves the iterator to the next element and returns true if there was a next element in the container.
+// If Next() returns true, then next element's index and value can be retrieved by Index() and Value().
+// If Next() was called for the first time, then it will point the iterator to the first element if it exists.
+// Modifies the state of the iterator.
+func (iterator *Iterator) Next() bool {
+	if iterator.index < iterator.queue.Size() {
+		iterator.index++
+	}
+	return iterator.queue.withinRange(iterator.index)
+}
+
+// Value returns the current element's value.
+// Does not modify the state of the iterator.
+func (iterator *Iterator) Value() interface{} {
+	value, _ := iterator.queue.list.Get(iterator.index) // FIFO
+	return value
+}
+
+// Index returns the current element's index.
+// Does not modify the state of the iterator.
+func (iterator *Iterator) Index() int {
+	return iterator.index
+}
+
+// Begin resets the iterator to its initial state (one-before-first)
+// Call Next() to fetch the first element if any.
+func (iterator *Iterator) Begin() {
+	iterator.index = -1
+}
+
+// First moves the iterator to the first element and returns true if there was a first element in the container.
+// If First() returns true, then first element's index and value can be retrieved by Index() and Value().
+// Modifies the state of the iterator.
+func (iterator *Iterator) First() bool {
+	iterator.Begin()
+	return iterator.Next()
+}

--- a/queues/linkedlistqueue/linkedlistqueue.go
+++ b/queues/linkedlistqueue/linkedlistqueue.go
@@ -1,0 +1,78 @@
+package linkedlistqueue
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/emirpasic/gods/lists/singlylinkedlist"
+	"github.com/emirpasic/gods/queues"
+)
+
+func assertStackImplementation() {
+	var _ queues.Queue = (*Queue)(nil)
+}
+
+// Queue holds elements in a singly-linked-list
+type Queue struct {
+	list *singlylinkedlist.List
+}
+
+// New nnstantiates a new empty queue
+func New() *Queue {
+	return &Queue{list: &singlylinkedlist.List{}}
+}
+
+// Push adds a value at the back of the queue.
+func (queue *Queue) Push(value interface{}) {
+	queue.list.Append(value)
+}
+
+// Pop removes front element in queue and returns it, or nil if queue is empty.
+// Second return parameter is true, unless the queue was empty and there was nothing to pop.
+func (queue *Queue) Pop() (value interface{}, ok bool) {
+	value, ok = queue.list.Get(0)
+	queue.list.Remove(0)
+	return
+}
+
+// Peek returns front element in the queue without removing it, or nil if queue is empty.
+// Second return parameter is true, unless the queue was empty and there was nothing to peek.
+func (queue *Queue) Peek() (value interface{}, ok bool) {
+	return queue.list.Get(0)
+}
+
+// Empty returns true if queue does not contain any elements.
+func (queue *Queue) Empty() bool {
+	return queue.list.Empty()
+}
+
+// Size returns number of elements within the queue.
+func (queue *Queue) Size() int {
+	return queue.list.Size()
+}
+
+// Clear removes all elements from the queue.
+func (queue *Queue) Clear() {
+	queue.list.Clear()
+}
+
+// Values returns all elements in the queue (FIFO order).
+func (queue *Queue) Values() []interface{} {
+	return queue.list.Values()
+}
+
+// String returns a string representation of container
+func (queue *Queue) String() string {
+	str := "LinkedListQueue\n"
+	values := []string{}
+	for _, value := range queue.list.Values() {
+		values = append(values, fmt.Sprintf("%v", value))
+	}
+	str += strings.Join(values, ", ")
+	return str
+}
+
+// Check that the index is within bounds of the list
+func (queue *Queue) withinRange(index int) bool {
+	return index >= 0 && index < queue.list.Size()
+}

--- a/queues/linkedlistqueue/linkedlistqueue_test.go
+++ b/queues/linkedlistqueue/linkedlistqueue_test.go
@@ -1,0 +1,274 @@
+package linkedlistqueue
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestQueuePush(t *testing.T) {
+	queue := New()
+	if actualValue := queue.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	queue.Push(1)
+	queue.Push(2)
+	queue.Push(3)
+
+	if actualValue := queue.Values(); actualValue[0].(int) != 1 || actualValue[1].(int) != 2 || actualValue[2].(int) != 3 {
+		t.Errorf("Got %v expected %v", actualValue, "[1,2,3]")
+	}
+	if actualValue := queue.Empty(); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+	if actualValue := queue.Size(); actualValue != 3 {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+	if actualValue, ok := queue.Peek(); actualValue != 1 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 1)
+	}
+}
+
+func TestQueuePeek(t *testing.T) {
+	queue := New()
+	if actualValue, ok := queue.Peek(); actualValue != nil || ok {
+		t.Errorf("Got %v expected %v", actualValue, nil)
+	}
+	queue.Push(1)
+	queue.Push(2)
+	queue.Push(3)
+	if actualValue, ok := queue.Peek(); actualValue != 1 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 1)
+	}
+}
+
+func TestQueuePop(t *testing.T) {
+	queue := New()
+	queue.Push(1)
+	queue.Push(2)
+	queue.Push(3)
+	queue.Pop()
+	if actualValue, ok := queue.Peek(); actualValue != 2 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	if actualValue, ok := queue.Pop(); actualValue != 2 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	if actualValue, ok := queue.Pop(); actualValue != 3 || !ok {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+	if actualValue, ok := queue.Pop(); actualValue != nil || ok {
+		t.Errorf("Got %v expected %v", actualValue, nil)
+	}
+	if actualValue := queue.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := queue.Values(); len(actualValue) != 0 {
+		t.Errorf("Got %v expected %v", actualValue, "[]")
+	}
+}
+
+func TestQueueIterator(t *testing.T) {
+	queue := New()
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+
+	// Iterator
+	it := queue.Iterator()
+	count := 0
+	for it.Next() {
+		count++
+		index := it.Index()
+		value := it.Value()
+		switch index {
+		case 0:
+			if actualValue, expectedValue := value, "a"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		case 1:
+			if actualValue, expectedValue := value, "b"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		case 2:
+			if actualValue, expectedValue := value, "c"; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			}
+		default:
+			t.Errorf("Too many")
+		}
+		if actualValue, expectedValue := index, count-1; actualValue != expectedValue {
+			t.Errorf("Got %v expected %v", actualValue, expectedValue)
+		}
+	}
+	if actualValue, expectedValue := count, 3; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+
+	queue.Clear()
+	it = queue.Iterator()
+	for it.Next() {
+		t.Errorf("Shouldn't iterate on empty queue")
+	}
+}
+
+func TestQueueIteratorBegin(t *testing.T) {
+	queue := New()
+	it := queue.Iterator()
+	it.Begin()
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+	for it.Next() {
+	}
+	it.Begin()
+	it.Next()
+	if index, value := it.Index(), it.Value(); index != 0 || value != "a" {
+		t.Errorf("Got %v,%v expected %v,%v", index, value, 0, "a")
+	}
+}
+
+func TestQueueIteratorFirst(t *testing.T) {
+	queue := New()
+	it := queue.Iterator()
+	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+	if actualValue, expectedValue := it.First(), true; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if index, value := it.Index(), it.Value(); index != 0 || value != "a" {
+		t.Errorf("Got %v,%v expected %v,%v", index, value, 0, "a")
+	}
+}
+
+func TestQueueSerialization(t *testing.T) {
+	queue := New()
+	queue.Push("a")
+	queue.Push("b")
+	queue.Push("c")
+
+	var err error
+	assert := func() {
+		if actualValue, expectedValue := fmt.Sprintf("%s%s%s", queue.Values()...), "abc"; actualValue != expectedValue {
+			t.Errorf("Got %v expected %v", actualValue, expectedValue)
+		}
+		if actualValue, expectedValue := queue.Size(), 3; actualValue != expectedValue {
+			t.Errorf("Got %v expected %v", actualValue, expectedValue)
+		}
+		if err != nil {
+			t.Errorf("Got error %v", err)
+		}
+	}
+
+	assert()
+
+	json, err := queue.ToJSON()
+	assert()
+
+	err = queue.FromJSON(json)
+	assert()
+}
+
+func benchmarkPush(b *testing.B, queue *Queue, size int) {
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < size; n++ {
+			queue.Push(n)
+		}
+	}
+}
+
+func benchmarkPop(b *testing.B, queue *Queue, size int) {
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < size; n++ {
+			queue.Pop()
+		}
+	}
+}
+
+func BenchmarkLinkedListQueuePop100(b *testing.B) {
+	b.StopTimer()
+	size := 100
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPop(b, queue, size)
+}
+
+func BenchmarkLinkedListQueuePop1000(b *testing.B) {
+	b.StopTimer()
+	size := 1000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPop(b, queue, size)
+}
+
+func BenchmarkLinkedListQueuePop10000(b *testing.B) {
+	b.StopTimer()
+	size := 10000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPop(b, queue, size)
+}
+
+func BenchmarkLinkedListQueuePop100000(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPop(b, queue, size)
+}
+
+func BenchmarkLinkedListQueuePush100(b *testing.B) {
+	b.StopTimer()
+	size := 100
+	queue := New()
+	b.StartTimer()
+	benchmarkPush(b, queue, size)
+}
+
+func BenchmarkLinkedListQueuePush1000(b *testing.B) {
+	b.StopTimer()
+	size := 1000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPush(b, queue, size)
+}
+
+func BenchmarkLinkedListQueuePush10000(b *testing.B) {
+	b.StopTimer()
+	size := 10000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPush(b, queue, size)
+}
+
+func BenchmarkLinkedListQueuePush100000(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	queue := New()
+	for n := 0; n < size; n++ {
+		queue.Push(n)
+	}
+	b.StartTimer()
+	benchmarkPush(b, queue, size)
+}

--- a/queues/linkedlistqueue/serialization.go
+++ b/queues/linkedlistqueue/serialization.go
@@ -1,0 +1,18 @@
+package linkedlistqueue
+
+import "github.com/emirpasic/gods/containers"
+
+func assertSerializationImplementation() {
+	var _ containers.JSONSerializer = (*Queue)(nil)
+	var _ containers.JSONDeserializer = (*Queue)(nil)
+}
+
+// ToJSON outputs the JSON representation of the queue.
+func (queue *Queue) ToJSON() ([]byte, error) {
+	return queue.list.ToJSON()
+}
+
+// FromJSON populates the queue from the input JSON representation.
+func (queue *Queue) FromJSON(data []byte) error {
+	return queue.list.FromJSON(data)
+}

--- a/queues/queues.go
+++ b/queues/queues.go
@@ -1,0 +1,15 @@
+package queues
+
+import "github.com/emirpasic/gods/containers"
+
+type Queue interface {
+	Push(value interface{})
+	Pop() (value interface{}, ok bool)
+	Peek() (value interface{}, ok bool)
+
+	containers.Container
+	// Empty() bool
+	// Size() int
+	// Clear()
+	// Values() []interface{}
+}


### PR DESCRIPTION
I implemented the `queues` package in these two forms.
For the `Pop()` method of arrayqueue, I implemented `RemoveFirstElem()` in arraylist.go and used it in this method to avoid copy operation.