### PR TITLE
Benchmark bug fixed(interface conversion).

### DIFF
--- a/queues/priorityqueue/priorityqueue_test.go
+++ b/queues/priorityqueue/priorityqueue_test.go
@@ -476,7 +476,7 @@ func TestBTreeString(t *testing.T) {
 func benchmarkEnqueue(b *testing.B, queue *Queue, size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
-			queue.Enqueue(n)
+			queue.Enqueue(Element{})
 		}
 	}
 }
@@ -494,7 +494,7 @@ func BenchmarkBinaryQueueDequeue100(b *testing.B) {
 	size := 100
 	queue := NewWith(byPriority)
 	for n := 0; n < size; n++ {
-		queue.Enqueue(n)
+		queue.Enqueue(Element{})
 	}
 	b.StartTimer()
 	benchmarkDequeue(b, queue, size)
@@ -505,7 +505,7 @@ func BenchmarkBinaryQueueDequeue1000(b *testing.B) {
 	size := 1000
 	queue := NewWith(byPriority)
 	for n := 0; n < size; n++ {
-		queue.Enqueue(n)
+		queue.Enqueue(Element{})
 	}
 	b.StartTimer()
 	benchmarkDequeue(b, queue, size)
@@ -516,7 +516,7 @@ func BenchmarkBinaryQueueDequeue10000(b *testing.B) {
 	size := 10000
 	queue := NewWith(byPriority)
 	for n := 0; n < size; n++ {
-		queue.Enqueue(n)
+		queue.Enqueue(Element{})
 	}
 	b.StartTimer()
 	benchmarkDequeue(b, queue, size)
@@ -527,7 +527,7 @@ func BenchmarkBinaryQueueDequeue100000(b *testing.B) {
 	size := 100000
 	queue := NewWith(byPriority)
 	for n := 0; n < size; n++ {
-		queue.Enqueue(n)
+		queue.Enqueue(Element{})
 	}
 	b.StartTimer()
 	benchmarkDequeue(b, queue, size)
@@ -546,7 +546,7 @@ func BenchmarkBinaryQueueEnqueue1000(b *testing.B) {
 	size := 1000
 	queue := NewWith(byPriority)
 	for n := 0; n < size; n++ {
-		queue.Enqueue(n)
+		queue.Enqueue(Element{})
 	}
 	b.StartTimer()
 	benchmarkEnqueue(b, queue, size)
@@ -557,7 +557,7 @@ func BenchmarkBinaryQueueEnqueue10000(b *testing.B) {
 	size := 10000
 	queue := NewWith(byPriority)
 	for n := 0; n < size; n++ {
-		queue.Enqueue(n)
+		queue.Enqueue(Element{})
 	}
 	b.StartTimer()
 	benchmarkEnqueue(b, queue, size)
@@ -568,7 +568,7 @@ func BenchmarkBinaryQueueEnqueue100000(b *testing.B) {
 	size := 100000
 	queue := NewWith(byPriority)
 	for n := 0; n < size; n++ {
-		queue.Enqueue(n)
+		queue.Enqueue(Element{})
 	}
 	b.StartTimer()
 	benchmarkEnqueue(b, queue, size)


### PR DESCRIPTION
go test -run=NO_TEST -bench . -benchmem -benchtime 1s
This command gives an error (panic: interface conversion: interface {} is int, not priorityqueue.Element) and to fix this enqueue(n)s changed to enqueu(Element{})s.