### PR TITLE
fix: doublylinkedlist insertion with last to first traversal

### DIFF
--- a/lists/doublylinkedlist/doublylinkedlist.go
+++ b/lists/doublylinkedlist/doublylinkedlist.go
@@ -177,7 +177,7 @@ func (list *List) Values() []interface{} {
 	return values
 }
 
-//IndexOf returns index of provided element
+// IndexOf returns index of provided element
 func (list *List) IndexOf(value interface{}) int {
 	if list.size == 0 {
 		return -1
@@ -252,15 +252,14 @@ func (list *List) Insert(index int, values ...interface{}) {
 		return
 	}
 
-	list.size += len(values)
-
 	var beforeElement *element
 	var foundElement *element
 	// determine traversal direction, last to first or first to last
 	if list.size-index < index {
 		foundElement = list.last
+		beforeElement = list.last.prev
 		for e := list.size - 1; e != index; e, foundElement = e-1, foundElement.prev {
-			beforeElement = foundElement.prev
+			beforeElement = beforeElement.prev
 		}
 	} else {
 		foundElement = list.first
@@ -294,6 +293,8 @@ func (list *List) Insert(index int, values ...interface{}) {
 		oldNextElement.prev = beforeElement
 		beforeElement.next = oldNextElement
 	}
+
+	list.size += len(values)
 }
 
 // Set value at specified index position

--- a/lists/doublylinkedlist/doublylinkedlist_test.go
+++ b/lists/doublylinkedlist/doublylinkedlist_test.go
@@ -213,17 +213,24 @@ func TestListIndexOf(t *testing.T) {
 
 func TestListInsert(t *testing.T) {
 	list := New()
-	list.Insert(0, "b", "c")
+	list.Insert(0, "b", "c", "d")
 	list.Insert(0, "a")
 	list.Insert(10, "x") // ignore
-	if actualValue := list.Size(); actualValue != 3 {
-		t.Errorf("Got %v expected %v", actualValue, 3)
-	}
-	list.Insert(3, "d") // append
 	if actualValue := list.Size(); actualValue != 4 {
 		t.Errorf("Got %v expected %v", actualValue, 4)
 	}
-	if actualValue, expectedValue := fmt.Sprintf("%s%s%s%s", list.Values()...), "abcd"; actualValue != expectedValue {
+	list.Insert(4, "g") // append
+	if actualValue := list.Size(); actualValue != 5 {
+		t.Errorf("Got %v expected %v", actualValue, 5)
+	}
+	if actualValue, expectedValue := fmt.Sprintf("%s%s%s%s%s", list.Values()...), "abcdg"; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	list.Insert(4, "e", "f") // last to first traversal
+	if actualValue := list.Size(); actualValue != 7 {
+		t.Errorf("Got %v expected %v", actualValue, 7)
+	}
+	if actualValue, expectedValue := fmt.Sprintf("%s%s%s%s%s%s%s", list.Values()...), "abcdefg"; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
 }


### PR DESCRIPTION
This was an untested path of the implementation. Bit me today while doing some AoC problems in Go.