### PR TITLE
Fix CircularBuffer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -973,11 +973,11 @@ func main() {
     queue.Enqueue(2)       // 1, 2
     queue.Enqueue(3)       // 1, 2, 3
     _ = queue.Values()     // 1, 2, 3
-    queue.Enqueue(3)       // 4, 2, 3
-    _, _ = queue.Peek()    // 4,true
-    _, _ = queue.Dequeue() // 4, true
+    queue.Enqueue(4)       // 4, 2, 3
+    _, _ = queue.Peek()    // 2,true
     _, _ = queue.Dequeue() // 2, true
     _, _ = queue.Dequeue() // 3, true
+    _, _ = queue.Dequeue() // 4, true
     _, _ = queue.Dequeue() // nil, false (nothing to deque)
     queue.Enqueue(1)       // 1
     queue.Clear()          // empty


### PR DESCRIPTION
When calling ` queue.Enqueue (4) `, the queue is full and will be calling `queue.Dequeue` -->  `queue. start++`

so the `queue.Peek` will return `queue.values[queue. start]` is 2