### PR TITLE
fix arraylist unmarshalling

### DIFF
--- a/lists/arraylist/arraylist_test.go
+++ b/lists/arraylist/arraylist_test.go
@@ -642,6 +642,31 @@ func TestListSerialization(t *testing.T) {
 	assert()
 }
 
+func TestListSerializationCapacity(t *testing.T) {
+	nums := make([]int, 100)
+	for i := 0; i < 100; i++ {
+		nums[i] = i
+	}
+	list := New(nums...)
+
+	var err error
+	assert := func() {
+		if actualCapacity, expectedCapacity := cap(list.elements), 100; actualCapacity != expectedCapacity {
+			t.Errorf("Got cap=%d expected cap=%d", actualCapacity, expectedCapacity)
+		}
+		if actualLength, expectedLength := len(list.elements), 100; actualLength != expectedLength {
+			t.Errorf("Got len=%d expected len=%d", actualLength, expectedLength)
+		}
+	}
+
+	bytes, err := list.ToJSON()
+	err = list.FromJSON(bytes)
+	if err != nil {
+		t.Errorf("Got error %v", err)
+	}
+	assert()
+}
+
 func TestListString(t *testing.T) {
 	c := New[int]()
 	c.Add(1)

--- a/lists/arraylist/serialization.go
+++ b/lists/arraylist/serialization.go
@@ -24,6 +24,7 @@ func (list *List[T]) FromJSON(data []byte) error {
 	err := json.Unmarshal(data, &list.elements)
 	if err == nil {
 		list.size = len(list.elements)
+		list.elements = list.elements[:len(list.elements):len(list.elements)]
 	}
 	return err
 }


### PR DESCRIPTION
When calling `json.Unmarshal(data, &list.elements)` the `cap(list.elements)` is usually larger than the actual length. In that case the check in the `growBy` function fails and `list.elements` size is not adjusted.
Maybe I'm missing something here but from what I can tell, the `resize` function always ensures that the length is equal to the capacity.