### PR TITLE
Improve circularbuffer performance by removing redundant fields

### DIFF
--- a/queues/circularbuffer/iterator.go
+++ b/queues/circularbuffer/iterator.go
@@ -44,7 +44,7 @@ func (iterator *Iterator[T]) Prev() bool {
 // Value returns the current element's value.
 // Does not modify the state of the iterator.
 func (iterator *Iterator[T]) Value() T {
-	index := (iterator.index + iterator.queue.start) % iterator.queue.maxSize
+	index := (iterator.index + iterator.queue.start) % len(iterator.queue.values)
 	value := iterator.queue.values[index]
 	return value
 }

--- a/queues/circularbuffer/serialization.go
+++ b/queues/circularbuffer/serialization.go
@@ -16,7 +16,7 @@ var _ containers.JSONDeserializer = (*Queue[int])(nil)
 
 // ToJSON outputs the JSON representation of queue's elements.
 func (queue *Queue[T]) ToJSON() ([]byte, error) {
-	return json.Marshal(queue.values[:queue.maxSize])
+	return json.Marshal(queue.values)
 }
 
 // FromJSON populates list's elements from the input JSON representation.


### PR DESCRIPTION
We can maintain `maxSize` using the capacity and length of `values`, and determine the `full` flag by checking whether `size` is equal to the capacity (or length) of `values`.

In addition, in `Enqueue()`, when the queue is full, we can simply update the value of `start` instead of calling `Dequeue()`, as the overhead of calling `Dequeue()` is higher than updating the value of `start`.

+ Achieve an average reduction of nearly **27%** in execution time for `ArrayQueueDequeue`.
+ Achieve an average reduction of nearly **32%** in  execution time for `ArrayQueueEnqueue`.

```
goos: linux
goarch: amd64
pkg: github.com/emirpasic/gods/v2/queues/circularbuffer
cpu: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
                          │   old.txt   │           new.txt           │
                          │   sec/op    │   sec/op     vs base        │
ArrayQueueDequeue100-8      43.09n ± 1%   33.10n ± 0%  -23.20% (n=50)
ArrayQueueDequeue1000-8     359.5n ± 0%   260.6n ± 0%  -27.52% (n=50)
ArrayQueueDequeue10000-8    3.541µ ± 0%   2.530µ ± 0%  -28.55% (n=50)
ArrayQueueDequeue100000-8   35.24µ ± 0%   25.19µ ± 0%  -28.52% (n=50)
ArrayQueueEnqueue100-8      488.9n ± 0%   331.3n ± 0%  -32.23% (n=50)
ArrayQueueEnqueue1000-8     4.826µ ± 0%   3.316µ ± 0%  -31.30% (n=50)
ArrayQueueEnqueue10000-8    48.23µ ± 0%   33.21µ ± 1%  -31.16% (n=50)
ArrayQueueEnqueue100000-8   482.7µ ± 0%   331.0µ ± 0%  -31.43% (n=50)
geomean                     4.249µ        3.004µ       -29.29%

                          │   old.txt    │               new.txt               │
                          │     B/op     │    B/op     vs base                 │
ArrayQueueDequeue100-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueDequeue1000-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueDequeue10000-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueDequeue100000-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueEnqueue100-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueEnqueue1000-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueEnqueue10000-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueEnqueue100000-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
geomean                                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                          │   old.txt    │               new.txt               │
                          │  allocs/op   │ allocs/op   vs base                 │
ArrayQueueDequeue100-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueDequeue1000-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueDequeue10000-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueDequeue100000-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueEnqueue100-8      0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueEnqueue1000-8     0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueEnqueue10000-8    0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
ArrayQueueEnqueue100000-8   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=50) ¹
geomean                                ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```