### PR TITLE
Improve doublylikedlist IndexOf() by reducing the space complexity from O(n) to O(1)

### DIFF
--- a/lists/doublylinkedlist/doublylinkedlist.go
+++ b/lists/doublylinkedlist/doublylinkedlist.go
@@ -88,7 +88,7 @@ func (list *List[T]) Get(index int) (T, bool) {
 		return t, false
 	}
 
-	// determine traveral direction, last to first or first to last
+	// determine traversal direction, last to first or first to last
 	if list.size-index < index {
 		element := list.last
 		for e := list.size - 1; e != index; e, element = e-1, element.prev {
@@ -172,7 +172,7 @@ func (list *List[T]) Contains(values ...T) bool {
 
 // Values returns all elements in the list.
 func (list *List[T]) Values() []T {
-	values := make([]T, list.size, list.size)
+	values := make([]T, list.size)
 	for e, element := 0, list.first; element != nil; e, element = e+1, element.next {
 		values[e] = element.value
 	}
@@ -181,12 +181,9 @@ func (list *List[T]) Values() []T {
 
 // IndexOf returns index of provided element
 func (list *List[T]) IndexOf(value T) int {
-	if list.size == 0 {
-		return -1
-	}
-	for index, element := range list.Values() {
-		if element == value {
-			return index
+	for e, element := 0, list.first; element != nil; e, element = e+1, element.next {
+		if element.value == value {
+			return e
 		}
 	}
 	return -1


### PR DESCRIPTION
Implement `IndexOf()` without calling `Values()`.

I also checked the performance by running the benchmark I made. Both practical benchmark results and theoretical analysis show that the new implementation significantly improves runtime performance and memory usage

```go
func benchmarkIndexOf(b *testing.B, list *List[int], size int) {
	for i := 0; i < b.N; i++ {
		for n := 0; n < size/4; n++ {
			list.IndexOf(n / 4)
			list.IndexOf(n / 2)
			list.IndexOf(n/4 + n/2)
			list.IndexOf(n - 1)
		}
	}
}

func BenchmarkDoublyLinkedListIndexOf100(b *testing.B) {
	b.StopTimer()
	size := 1000
	list := New[int]()
	for n := 0; n < size; n++ {
		list.Add(n)
	}
	b.StartTimer()
	benchmarkIndexOf(b, list, size)
}

func BenchmarkDoublyLinkedListIndexOf1000(b *testing.B) {
	b.StopTimer()
	size := 1000
	list := New[int]()
	for n := 0; n < size; n++ {
		list.Add(n)
	}
	b.StartTimer()
	benchmarkIndexOf(b, list, size)
}

func BenchmarkDoublyLinkedListIndexOf10000(b *testing.B) {
	b.StopTimer()
	size := 10000
	list := New[int]()
	for n := 0; n < size; n++ {
		list.Add(n)
	}
	b.StartTimer()
	benchmarkIndexOf(b, list, size)
}
```

```
goos: linux
goarch: amd64
pkg: github.com/emirpasic/gods/v2/lists/doublylinkedlist
cpu: Intel(R) Core(TM) i7-4790 CPU @ 3.60GHz
                               │     old.txt     │               new.txt               │
                               │     sec/op      │   sec/op     vs base                │
DoublyLinkedListIndexOf100-8      8747.80µ ± 24%   85.20µ ± 1%  -99.03% (p=0.000 n=10)
DoublyLinkedListIndexOf1000-8     8926.62µ ± 22%   85.03µ ± 1%  -99.05% (p=0.000 n=10)
DoublyLinkedListIndexOf10000-8   1056.877m ± 27%   8.933m ± 1%  -99.15% (p=0.000 n=10)
geomean                             43.54m         401.5µ       -99.08%

                               │   old.txt    │                  new.txt                  │
                               │     B/op     │     B/op      vs base                     │
DoublyLinkedListIndexOf100-8     7.813Mi ± 0%   0.000Mi ± 0%  -100.00% (p=0.000 n=10)
DoublyLinkedListIndexOf1000-8    7.813Mi ± 0%   0.000Mi ± 0%  -100.00% (p=0.000 n=10)
DoublyLinkedListIndexOf10000-8   781.3Mi ± 0%     0.0Mi ± 0%  -100.00% (p=0.000 n=10)
geomean                          36.26Mi                      ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean

                               │   old.txt   │                 new.txt                  │
                               │  allocs/op  │  allocs/op   vs base                     │
DoublyLinkedListIndexOf100-8     1.000k ± 0%   0.000k ± 0%  -100.00% (p=0.000 n=10)
DoublyLinkedListIndexOf1000-8    1.000k ± 0%   0.000k ± 0%  -100.00% (p=0.000 n=10)
DoublyLinkedListIndexOf10000-8   10.01k ± 0%    0.00k ± 0%  -100.00% (p=0.000 n=10)
geomean                          2.155k                     ?                       ¹ ²
¹ summaries must be >0 to compute geomean
² ratios must be >0 to compute geomean
```