### PR TITLE
Migrate to '_test' package idiom

### DIFF
--- a/containers/containers_test.go
+++ b/containers/containers_test.go
@@ -4,13 +4,15 @@
 
 // All data structures must implement the container structure
 
-package containers
+package containers_test
 
 import (
 	"cmp"
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/containers"
 )
 
 // For testing purposes
@@ -46,9 +48,9 @@ func (container ContainerTest[T]) String() string {
 
 func TestGetSortedValuesInts(t *testing.T) {
 	container := ContainerTest[int]{}
-	GetSortedValues(container)
+	containers.GetSortedValues(container)
 	container.values = []int{5, 1, 3, 2, 4}
-	values := GetSortedValues(container)
+	values := containers.GetSortedValues(container)
 	for i := 1; i < container.Size(); i++ {
 		if values[i-1] > values[i] {
 			t.Errorf("Not sorted!")
@@ -62,11 +64,11 @@ type NotInt struct {
 
 func TestGetSortedValuesNotInts(t *testing.T) {
 	container := ContainerTest[NotInt]{}
-	GetSortedValuesFunc(container, func(x, y NotInt) int {
+	containers.GetSortedValuesFunc(container, func(x, y NotInt) int {
 		return cmp.Compare(x.i, y.i)
 	})
 	container.values = []NotInt{{5}, {1}, {3}, {2}, {4}}
-	values := GetSortedValuesFunc(container, func(x, y NotInt) int {
+	values := containers.GetSortedValuesFunc(container, func(x, y NotInt) int {
 		return cmp.Compare(x.i, y.i)
 	})
 	for i := 1; i < container.Size(); i++ {

--- a/lists/arraylist/arraylist_test.go
+++ b/lists/arraylist/arraylist_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package arraylist
+package arraylist_test
 
 import (
 	"cmp"
@@ -10,16 +10,18 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/lists/arraylist"
 )
 
 func TestListNew(t *testing.T) {
-	list1 := New[int]()
+	list1 := arraylist.New[int]()
 
 	if actualValue := list1.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
 	}
 
-	list2 := New[int](1, 2)
+	list2 := arraylist.New[int](1, 2)
 
 	if actualValue := list2.Size(); actualValue != 2 {
 		t.Errorf("Got %v expected %v", actualValue, 2)
@@ -39,7 +41,7 @@ func TestListNew(t *testing.T) {
 }
 
 func TestListAdd(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue := list.Empty(); actualValue != false {
@@ -54,7 +56,7 @@ func TestListAdd(t *testing.T) {
 }
 
 func TestListIndexOf(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 
 	expectedIndex := -1
 	if index := list.IndexOf("a"); index != expectedIndex {
@@ -81,7 +83,7 @@ func TestListIndexOf(t *testing.T) {
 }
 
 func TestListRemove(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	list.Remove(2)
@@ -100,7 +102,7 @@ func TestListRemove(t *testing.T) {
 }
 
 func TestListGet(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue, ok := list.Get(0); actualValue != "a" || !ok {
@@ -122,7 +124,7 @@ func TestListGet(t *testing.T) {
 }
 
 func TestListSwap(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	list.Swap(0, 1)
@@ -132,7 +134,7 @@ func TestListSwap(t *testing.T) {
 }
 
 func TestListSort(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Sort(cmp.Compare[string])
 	list.Add("e", "f", "g", "a", "b", "c", "d")
 	list.Sort(cmp.Compare[string])
@@ -146,7 +148,7 @@ func TestListSort(t *testing.T) {
 }
 
 func TestListClear(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("e", "f", "g", "a", "b", "c", "d")
 	list.Clear()
 	if actualValue := list.Empty(); actualValue != true {
@@ -158,7 +160,7 @@ func TestListClear(t *testing.T) {
 }
 
 func TestListContains(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue := list.Contains("a"); actualValue != true {
@@ -183,7 +185,7 @@ func TestListContains(t *testing.T) {
 }
 
 func TestListValues(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue, expectedValue := list.Values(), []string{"a", "b", "c"}; !slices.Equal(actualValue, expectedValue) {
@@ -192,7 +194,7 @@ func TestListValues(t *testing.T) {
 }
 
 func TestListInsert(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Insert(0, "b", "c")
 	list.Insert(0, "a")
 	list.Insert(10, "x") // ignore
@@ -209,7 +211,7 @@ func TestListInsert(t *testing.T) {
 }
 
 func TestListSet(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Set(0, "a")
 	list.Set(1, "b")
 	if actualValue := list.Size(); actualValue != 2 {
@@ -230,7 +232,7 @@ func TestListSet(t *testing.T) {
 }
 
 func TestListEach(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a", "b", "c")
 	list.Each(func(index int, value string) {
 		switch index {
@@ -253,7 +255,7 @@ func TestListEach(t *testing.T) {
 }
 
 func TestListMap(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a", "b", "c")
 	mappedList := list.Map(func(index int, value string) string {
 		return "mapped: " + value
@@ -273,7 +275,7 @@ func TestListMap(t *testing.T) {
 }
 
 func TestListSelect(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a", "b", "c")
 	selectedList := list.Select(func(index int, value string) bool {
 		return value >= "a" && value <= "b"
@@ -290,7 +292,7 @@ func TestListSelect(t *testing.T) {
 }
 
 func TestListAny(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a", "b", "c")
 	any := list.Any(func(index int, value string) bool {
 		return value == "c"
@@ -306,7 +308,7 @@ func TestListAny(t *testing.T) {
 	}
 }
 func TestListAll(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a", "b", "c")
 	all := list.All(func(index int, value string) bool {
 		return value >= "a" && value <= "c"
@@ -322,7 +324,7 @@ func TestListAll(t *testing.T) {
 	}
 }
 func TestListFind(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a", "b", "c")
 	foundIndex, foundValue := list.Find(func(index int, value string) bool {
 		return value == "c"
@@ -338,7 +340,7 @@ func TestListFind(t *testing.T) {
 	}
 }
 func TestListChaining(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a", "b", "c")
 	chainedList := list.Select(func(index int, value string) bool {
 		return value > "a"
@@ -357,7 +359,7 @@ func TestListChaining(t *testing.T) {
 }
 
 func TestListIteratorNextOnEmpty(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	it := list.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty list")
@@ -365,7 +367,7 @@ func TestListIteratorNextOnEmpty(t *testing.T) {
 }
 
 func TestListIteratorNext(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a", "b", "c")
 	it := list.Iterator()
 	count := 0
@@ -396,7 +398,7 @@ func TestListIteratorNext(t *testing.T) {
 }
 
 func TestListIteratorPrevOnEmpty(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	it := list.Iterator()
 	for it.Prev() {
 		t.Errorf("Shouldn't iterate on empty list")
@@ -404,7 +406,7 @@ func TestListIteratorPrevOnEmpty(t *testing.T) {
 }
 
 func TestListIteratorPrev(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a", "b", "c")
 	it := list.Iterator()
 	for it.Next() {
@@ -437,7 +439,7 @@ func TestListIteratorPrev(t *testing.T) {
 }
 
 func TestListIteratorBegin(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	it := list.Iterator()
 	it.Begin()
 	list.Add("a", "b", "c")
@@ -451,7 +453,7 @@ func TestListIteratorBegin(t *testing.T) {
 }
 
 func TestListIteratorEnd(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	it := list.Iterator()
 
 	if index := it.Index(); index != -1 {
@@ -476,7 +478,7 @@ func TestListIteratorEnd(t *testing.T) {
 }
 
 func TestListIteratorFirst(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	it := list.Iterator()
 	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -491,7 +493,7 @@ func TestListIteratorFirst(t *testing.T) {
 }
 
 func TestListIteratorLast(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	it := list.Iterator()
 	if actualValue, expectedValue := it.Last(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -513,7 +515,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		list := New[string]()
+		list := arraylist.New[string]()
 		it := list.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty list")
@@ -522,7 +524,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		list := New[string]()
+		list := arraylist.New[string]()
 		list.Add("xx", "yy")
 		it := list.Iterator()
 		for it.NextTo(seek) {
@@ -532,7 +534,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		list := New[string]()
+		list := arraylist.New[string]()
 		list.Add("aa", "bb", "cc")
 		it := list.Iterator()
 		it.Begin()
@@ -562,7 +564,7 @@ func TestListIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		list := New[string]()
+		list := arraylist.New[string]()
 		it := list.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -572,7 +574,7 @@ func TestListIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		list := New[string]()
+		list := arraylist.New[string]()
 		list.Add("xx", "yy")
 		it := list.Iterator()
 		it.End()
@@ -583,7 +585,7 @@ func TestListIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		list := New[string]()
+		list := arraylist.New[string]()
 		list.Add("aa", "bb", "cc")
 		it := list.Iterator()
 		it.End()
@@ -606,7 +608,7 @@ func TestListIteratorPrevTo(t *testing.T) {
 }
 
 func TestListSerialization(t *testing.T) {
-	list := New[string]()
+	list := arraylist.New[string]()
 	list.Add("a", "b", "c")
 
 	var err error
@@ -643,14 +645,14 @@ func TestListSerialization(t *testing.T) {
 }
 
 func TestListString(t *testing.T) {
-	c := New[int]()
+	c := arraylist.New[int]()
 	c.Add(1)
 	if !strings.HasPrefix(c.String(), "ArrayList") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkGet(b *testing.B, list *List[int], size int) {
+func benchmarkGet(b *testing.B, list *arraylist.List[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			list.Get(n)
@@ -658,7 +660,7 @@ func benchmarkGet(b *testing.B, list *List[int], size int) {
 	}
 }
 
-func benchmarkAdd(b *testing.B, list *List[int], size int) {
+func benchmarkAdd(b *testing.B, list *arraylist.List[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			list.Add(n)
@@ -666,7 +668,7 @@ func benchmarkAdd(b *testing.B, list *List[int], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, list *List[int], size int) {
+func benchmarkRemove(b *testing.B, list *arraylist.List[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			list.Remove(n)
@@ -677,7 +679,7 @@ func benchmarkRemove(b *testing.B, list *List[int], size int) {
 func BenchmarkArrayListGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -688,7 +690,7 @@ func BenchmarkArrayListGet100(b *testing.B) {
 func BenchmarkArrayListGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -699,7 +701,7 @@ func BenchmarkArrayListGet1000(b *testing.B) {
 func BenchmarkArrayListGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -710,7 +712,7 @@ func BenchmarkArrayListGet10000(b *testing.B) {
 func BenchmarkArrayListGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -721,7 +723,7 @@ func BenchmarkArrayListGet100000(b *testing.B) {
 func BenchmarkArrayListAdd100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	list := New[int]()
+	list := arraylist.New[int]()
 	b.StartTimer()
 	benchmarkAdd(b, list, size)
 }
@@ -729,7 +731,7 @@ func BenchmarkArrayListAdd100(b *testing.B) {
 func BenchmarkArrayListAdd1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -740,7 +742,7 @@ func BenchmarkArrayListAdd1000(b *testing.B) {
 func BenchmarkArrayListAdd10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -751,7 +753,7 @@ func BenchmarkArrayListAdd10000(b *testing.B) {
 func BenchmarkArrayListAdd100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -762,7 +764,7 @@ func BenchmarkArrayListAdd100000(b *testing.B) {
 func BenchmarkArrayListRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -773,7 +775,7 @@ func BenchmarkArrayListRemove100(b *testing.B) {
 func BenchmarkArrayListRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -784,7 +786,7 @@ func BenchmarkArrayListRemove1000(b *testing.B) {
 func BenchmarkArrayListRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -795,7 +797,7 @@ func BenchmarkArrayListRemove10000(b *testing.B) {
 func BenchmarkArrayListRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	list := New[int]()
+	list := arraylist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}

--- a/lists/doublylinkedlist/doublylinkedlist_test.go
+++ b/lists/doublylinkedlist/doublylinkedlist_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package doublylinkedlist
+package doublylinkedlist_test
 
 import (
 	"cmp"
@@ -10,16 +10,18 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/lists/doublylinkedlist"
 )
 
 func TestListNew(t *testing.T) {
-	list1 := New[int]()
+	list1 := doublylinkedlist.New[int]()
 
 	if actualValue := list1.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
 	}
 
-	list2 := New[int](1, 2)
+	list2 := doublylinkedlist.New[int](1, 2)
 
 	if actualValue := list2.Size(); actualValue != 2 {
 		t.Errorf("Got %v expected %v", actualValue, 2)
@@ -39,7 +41,7 @@ func TestListNew(t *testing.T) {
 }
 
 func TestListAdd(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue := list.Empty(); actualValue != false {
@@ -54,7 +56,7 @@ func TestListAdd(t *testing.T) {
 }
 
 func TestListAppendAndPrepend(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("b")
 	list.Prepend("a")
 	list.Append("c")
@@ -76,7 +78,7 @@ func TestListAppendAndPrepend(t *testing.T) {
 }
 
 func TestListRemove(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	list.Remove(2)
@@ -95,7 +97,7 @@ func TestListRemove(t *testing.T) {
 }
 
 func TestListGet(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue, ok := list.Get(0); actualValue != "a" || !ok {
@@ -117,7 +119,7 @@ func TestListGet(t *testing.T) {
 }
 
 func TestListSwap(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	list.Swap(0, 1)
@@ -127,7 +129,7 @@ func TestListSwap(t *testing.T) {
 }
 
 func TestListSort(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Sort(cmp.Compare[string])
 	list.Add("e", "f", "g", "a", "b", "c", "d")
 	list.Sort(cmp.Compare[string])
@@ -141,7 +143,7 @@ func TestListSort(t *testing.T) {
 }
 
 func TestListClear(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("e", "f", "g", "a", "b", "c", "d")
 	list.Clear()
 	if actualValue := list.Empty(); actualValue != true {
@@ -153,7 +155,7 @@ func TestListClear(t *testing.T) {
 }
 
 func TestListContains(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue := list.Contains("a"); actualValue != true {
@@ -178,7 +180,7 @@ func TestListContains(t *testing.T) {
 }
 
 func TestListValues(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue, expectedValue := list.Values(), []string{"a", "b", "c"}; !slices.Equal(actualValue, expectedValue) {
@@ -187,7 +189,7 @@ func TestListValues(t *testing.T) {
 }
 
 func TestListInsert(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Insert(0, "b", "c", "d")
 	list.Insert(0, "a")
 	list.Insert(10, "x") // ignore
@@ -211,7 +213,7 @@ func TestListInsert(t *testing.T) {
 }
 
 func TestListSet(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Set(0, "a")
 	list.Set(1, "b")
 	if actualValue := list.Size(); actualValue != 2 {
@@ -232,7 +234,7 @@ func TestListSet(t *testing.T) {
 }
 
 func TestListEach(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	list.Each(func(index int, value string) {
 		switch index {
@@ -255,7 +257,7 @@ func TestListEach(t *testing.T) {
 }
 
 func TestListMap(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	mappedList := list.Map(func(index int, value string) string {
 		return "mapped: " + value
@@ -275,7 +277,7 @@ func TestListMap(t *testing.T) {
 }
 
 func TestListSelect(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	selectedList := list.Select(func(index int, value string) bool {
 		return value >= "a" && value <= "b"
@@ -292,7 +294,7 @@ func TestListSelect(t *testing.T) {
 }
 
 func TestListAny(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	any := list.Any(func(index int, value string) bool {
 		return value == "c"
@@ -308,7 +310,7 @@ func TestListAny(t *testing.T) {
 	}
 }
 func TestListAll(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	all := list.All(func(index int, value string) bool {
 		return value >= "a" && value <= "c"
@@ -324,7 +326,7 @@ func TestListAll(t *testing.T) {
 	}
 }
 func TestListFind(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	foundIndex, foundValue := list.Find(func(index int, value string) bool {
 		return value == "c"
@@ -340,7 +342,7 @@ func TestListFind(t *testing.T) {
 	}
 }
 func TestListChaining(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	chainedList := list.Select(func(index int, value string) bool {
 		return value > "a"
@@ -359,7 +361,7 @@ func TestListChaining(t *testing.T) {
 }
 
 func TestListIteratorNextOnEmpty(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	it := list.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty list")
@@ -367,7 +369,7 @@ func TestListIteratorNextOnEmpty(t *testing.T) {
 }
 
 func TestListIteratorNext(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	it := list.Iterator()
 	count := 0
@@ -398,7 +400,7 @@ func TestListIteratorNext(t *testing.T) {
 }
 
 func TestListIteratorPrevOnEmpty(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	it := list.Iterator()
 	for it.Prev() {
 		t.Errorf("Shouldn't iterate on empty list")
@@ -406,7 +408,7 @@ func TestListIteratorPrevOnEmpty(t *testing.T) {
 }
 
 func TestListIteratorPrev(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	it := list.Iterator()
 	for it.Next() {
@@ -439,7 +441,7 @@ func TestListIteratorPrev(t *testing.T) {
 }
 
 func TestListIteratorBegin(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	it := list.Iterator()
 	it.Begin()
 	list.Add("a", "b", "c")
@@ -453,7 +455,7 @@ func TestListIteratorBegin(t *testing.T) {
 }
 
 func TestListIteratorEnd(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	it := list.Iterator()
 
 	if index := it.Index(); index != -1 {
@@ -478,7 +480,7 @@ func TestListIteratorEnd(t *testing.T) {
 }
 
 func TestListIteratorFirst(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	it := list.Iterator()
 	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -493,7 +495,7 @@ func TestListIteratorFirst(t *testing.T) {
 }
 
 func TestListIteratorLast(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	it := list.Iterator()
 	if actualValue, expectedValue := it.Last(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -515,7 +517,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		list := New[string]()
+		list := doublylinkedlist.New[string]()
 		it := list.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty list")
@@ -524,7 +526,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		list := New[string]()
+		list := doublylinkedlist.New[string]()
 		list.Add("xx", "yy")
 		it := list.Iterator()
 		for it.NextTo(seek) {
@@ -534,7 +536,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		list := New[string]()
+		list := doublylinkedlist.New[string]()
 		list.Add("aa", "bb", "cc")
 		it := list.Iterator()
 		it.Begin()
@@ -564,7 +566,7 @@ func TestListIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		list := New[string]()
+		list := doublylinkedlist.New[string]()
 		it := list.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -574,7 +576,7 @@ func TestListIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		list := New[string]()
+		list := doublylinkedlist.New[string]()
 		list.Add("xx", "yy")
 		it := list.Iterator()
 		it.End()
@@ -585,7 +587,7 @@ func TestListIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		list := New[string]()
+		list := doublylinkedlist.New[string]()
 		list.Add("aa", "bb", "cc")
 		it := list.Iterator()
 		it.End()
@@ -608,7 +610,7 @@ func TestListIteratorPrevTo(t *testing.T) {
 }
 
 func TestListSerialization(t *testing.T) {
-	list := New[string]()
+	list := doublylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 
 	var err error
@@ -645,14 +647,14 @@ func TestListSerialization(t *testing.T) {
 }
 
 func TestListString(t *testing.T) {
-	c := New[int]()
+	c := doublylinkedlist.New[int]()
 	c.Add(1)
 	if !strings.HasPrefix(c.String(), "DoublyLinkedList") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkGet(b *testing.B, list *List[int], size int) {
+func benchmarkGet(b *testing.B, list *doublylinkedlist.List[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			list.Get(n)
@@ -660,7 +662,7 @@ func benchmarkGet(b *testing.B, list *List[int], size int) {
 	}
 }
 
-func benchmarkAdd(b *testing.B, list *List[int], size int) {
+func benchmarkAdd(b *testing.B, list *doublylinkedlist.List[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			list.Add(n)
@@ -668,7 +670,7 @@ func benchmarkAdd(b *testing.B, list *List[int], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, list *List[int], size int) {
+func benchmarkRemove(b *testing.B, list *doublylinkedlist.List[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			list.Remove(n)
@@ -679,7 +681,7 @@ func benchmarkRemove(b *testing.B, list *List[int], size int) {
 func BenchmarkDoublyLinkedListGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -690,7 +692,7 @@ func BenchmarkDoublyLinkedListGet100(b *testing.B) {
 func BenchmarkDoublyLinkedListGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -701,7 +703,7 @@ func BenchmarkDoublyLinkedListGet1000(b *testing.B) {
 func BenchmarkDoublyLinkedListGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -712,7 +714,7 @@ func BenchmarkDoublyLinkedListGet10000(b *testing.B) {
 func BenchmarkDoublyLinkedListGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -723,7 +725,7 @@ func BenchmarkDoublyLinkedListGet100000(b *testing.B) {
 func BenchmarkDoublyLinkedListAdd100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	b.StartTimer()
 	benchmarkAdd(b, list, size)
 }
@@ -731,7 +733,7 @@ func BenchmarkDoublyLinkedListAdd100(b *testing.B) {
 func BenchmarkDoublyLinkedListAdd1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -742,7 +744,7 @@ func BenchmarkDoublyLinkedListAdd1000(b *testing.B) {
 func BenchmarkDoublyLinkedListAdd10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -753,7 +755,7 @@ func BenchmarkDoublyLinkedListAdd10000(b *testing.B) {
 func BenchmarkDoublyLinkedListAdd100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -764,7 +766,7 @@ func BenchmarkDoublyLinkedListAdd100000(b *testing.B) {
 func BenchmarkDoublyLinkedListRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -775,7 +777,7 @@ func BenchmarkDoublyLinkedListRemove100(b *testing.B) {
 func BenchmarkDoublyLinkedListRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -786,7 +788,7 @@ func BenchmarkDoublyLinkedListRemove1000(b *testing.B) {
 func BenchmarkDoublyLinkedListRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -797,7 +799,7 @@ func BenchmarkDoublyLinkedListRemove10000(b *testing.B) {
 func BenchmarkDoublyLinkedListRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	list := New[int]()
+	list := doublylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}

--- a/lists/singlylinkedlist/singlylinkedlist_test.go
+++ b/lists/singlylinkedlist/singlylinkedlist_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package singlylinkedlist
+package singlylinkedlist_test
 
 import (
 	"cmp"
@@ -10,16 +10,18 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/lists/singlylinkedlist"
 )
 
 func TestListNew(t *testing.T) {
-	list1 := New[int]()
+	list1 := singlylinkedlist.New[int]()
 
 	if actualValue := list1.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
 	}
 
-	list2 := New[int](1, 2)
+	list2 := singlylinkedlist.New[int](1, 2)
 
 	if actualValue := list2.Size(); actualValue != 2 {
 		t.Errorf("Got %v expected %v", actualValue, 2)
@@ -39,7 +41,7 @@ func TestListNew(t *testing.T) {
 }
 
 func TestListAdd(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue := list.Empty(); actualValue != false {
@@ -54,7 +56,7 @@ func TestListAdd(t *testing.T) {
 }
 
 func TestListAppendAndPrepend(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("b")
 	list.Prepend("a")
 	list.Append("c")
@@ -76,7 +78,7 @@ func TestListAppendAndPrepend(t *testing.T) {
 }
 
 func TestListRemove(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	list.Remove(2)
@@ -95,7 +97,7 @@ func TestListRemove(t *testing.T) {
 }
 
 func TestListGet(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue, ok := list.Get(0); actualValue != "a" || !ok {
@@ -117,7 +119,7 @@ func TestListGet(t *testing.T) {
 }
 
 func TestListSwap(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	list.Swap(0, 1)
@@ -127,7 +129,7 @@ func TestListSwap(t *testing.T) {
 }
 
 func TestListSort(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Sort(cmp.Compare[string])
 	list.Add("e", "f", "g", "a", "b", "c", "d")
 	list.Sort(cmp.Compare[string])
@@ -141,7 +143,7 @@ func TestListSort(t *testing.T) {
 }
 
 func TestListClear(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("e", "f", "g", "a", "b", "c", "d")
 	list.Clear()
 	if actualValue := list.Empty(); actualValue != true {
@@ -153,7 +155,7 @@ func TestListClear(t *testing.T) {
 }
 
 func TestListContains(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue := list.Contains("a"); actualValue != true {
@@ -178,7 +180,7 @@ func TestListContains(t *testing.T) {
 }
 
 func TestListValues(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a")
 	list.Add("b", "c")
 	if actualValue, expectedValue := list.Values(), []string{"a", "b", "c"}; !slices.Equal(actualValue, expectedValue) {
@@ -187,7 +189,7 @@ func TestListValues(t *testing.T) {
 }
 
 func TestListIndexOf(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 
 	expectedIndex := -1
 	if index := list.IndexOf("a"); index != expectedIndex {
@@ -214,7 +216,7 @@ func TestListIndexOf(t *testing.T) {
 }
 
 func TestListInsert(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Insert(0, "b", "c")
 	list.Insert(0, "a")
 	list.Insert(10, "x") // ignore
@@ -231,7 +233,7 @@ func TestListInsert(t *testing.T) {
 }
 
 func TestListSet(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Set(0, "a")
 	list.Set(1, "b")
 	if actualValue := list.Size(); actualValue != 2 {
@@ -252,7 +254,7 @@ func TestListSet(t *testing.T) {
 }
 
 func TestListEach(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	list.Each(func(index int, value string) {
 		switch index {
@@ -275,7 +277,7 @@ func TestListEach(t *testing.T) {
 }
 
 func TestListMap(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	mappedList := list.Map(func(index int, value string) string {
 		return "mapped: " + value
@@ -295,7 +297,7 @@ func TestListMap(t *testing.T) {
 }
 
 func TestListSelect(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	selectedList := list.Select(func(index int, value string) bool {
 		return value >= "a" && value <= "b"
@@ -312,7 +314,7 @@ func TestListSelect(t *testing.T) {
 }
 
 func TestListAny(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	any := list.Any(func(index int, value string) bool {
 		return value == "c"
@@ -328,7 +330,7 @@ func TestListAny(t *testing.T) {
 	}
 }
 func TestListAll(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	all := list.All(func(index int, value string) bool {
 		return value >= "a" && value <= "c"
@@ -344,7 +346,7 @@ func TestListAll(t *testing.T) {
 	}
 }
 func TestListFind(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	foundIndex, foundValue := list.Find(func(index int, value string) bool {
 		return value == "c"
@@ -360,7 +362,7 @@ func TestListFind(t *testing.T) {
 	}
 }
 func TestListChaining(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	chainedList := list.Select(func(index int, value string) bool {
 		return value > "a"
@@ -379,7 +381,7 @@ func TestListChaining(t *testing.T) {
 }
 
 func TestListIteratorNextOnEmpty(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	it := list.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty list")
@@ -387,7 +389,7 @@ func TestListIteratorNextOnEmpty(t *testing.T) {
 }
 
 func TestListIteratorNext(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 	it := list.Iterator()
 	count := 0
@@ -418,7 +420,7 @@ func TestListIteratorNext(t *testing.T) {
 }
 
 func TestListIteratorBegin(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	it := list.Iterator()
 	it.Begin()
 	list.Add("a", "b", "c")
@@ -432,7 +434,7 @@ func TestListIteratorBegin(t *testing.T) {
 }
 
 func TestListIteratorFirst(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	it := list.Iterator()
 	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -454,7 +456,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		list := New[string]()
+		list := singlylinkedlist.New[string]()
 		it := list.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty list")
@@ -463,7 +465,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		list := New[string]()
+		list := singlylinkedlist.New[string]()
 		list.Add("xx", "yy")
 		it := list.Iterator()
 		for it.NextTo(seek) {
@@ -473,7 +475,7 @@ func TestListIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		list := New[string]()
+		list := singlylinkedlist.New[string]()
 		list.Add("aa", "bb", "cc")
 		it := list.Iterator()
 		it.Begin()
@@ -496,7 +498,7 @@ func TestListIteratorNextTo(t *testing.T) {
 }
 
 func TestListSerialization(t *testing.T) {
-	list := New[string]()
+	list := singlylinkedlist.New[string]()
 	list.Add("a", "b", "c")
 
 	var err error
@@ -533,14 +535,14 @@ func TestListSerialization(t *testing.T) {
 }
 
 func TestListString(t *testing.T) {
-	c := New[int]()
+	c := singlylinkedlist.New[int]()
 	c.Add(1)
 	if !strings.HasPrefix(c.String(), "SinglyLinkedList") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkGet(b *testing.B, list *List[int], size int) {
+func benchmarkGet(b *testing.B, list *singlylinkedlist.List[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			list.Get(n)
@@ -548,7 +550,7 @@ func benchmarkGet(b *testing.B, list *List[int], size int) {
 	}
 }
 
-func benchmarkAdd(b *testing.B, list *List[int], size int) {
+func benchmarkAdd(b *testing.B, list *singlylinkedlist.List[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			list.Add(n)
@@ -556,7 +558,7 @@ func benchmarkAdd(b *testing.B, list *List[int], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, list *List[int], size int) {
+func benchmarkRemove(b *testing.B, list *singlylinkedlist.List[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			list.Remove(n)
@@ -567,7 +569,7 @@ func benchmarkRemove(b *testing.B, list *List[int], size int) {
 func BenchmarkSinglyLinkedListGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -578,7 +580,7 @@ func BenchmarkSinglyLinkedListGet100(b *testing.B) {
 func BenchmarkSinglyLinkedListGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -589,7 +591,7 @@ func BenchmarkSinglyLinkedListGet1000(b *testing.B) {
 func BenchmarkSinglyLinkedListGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -600,7 +602,7 @@ func BenchmarkSinglyLinkedListGet10000(b *testing.B) {
 func BenchmarkSinglyLinkedListGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -611,7 +613,7 @@ func BenchmarkSinglyLinkedListGet100000(b *testing.B) {
 func BenchmarkSinglyLinkedListAdd100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	b.StartTimer()
 	benchmarkAdd(b, list, size)
 }
@@ -619,7 +621,7 @@ func BenchmarkSinglyLinkedListAdd100(b *testing.B) {
 func BenchmarkSinglyLinkedListAdd1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -630,7 +632,7 @@ func BenchmarkSinglyLinkedListAdd1000(b *testing.B) {
 func BenchmarkSinglyLinkedListAdd10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -641,7 +643,7 @@ func BenchmarkSinglyLinkedListAdd10000(b *testing.B) {
 func BenchmarkSinglyLinkedListAdd100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -652,7 +654,7 @@ func BenchmarkSinglyLinkedListAdd100000(b *testing.B) {
 func BenchmarkSinglyLinkedListRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -663,7 +665,7 @@ func BenchmarkSinglyLinkedListRemove100(b *testing.B) {
 func BenchmarkSinglyLinkedListRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -674,7 +676,7 @@ func BenchmarkSinglyLinkedListRemove1000(b *testing.B) {
 func BenchmarkSinglyLinkedListRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}
@@ -685,7 +687,7 @@ func BenchmarkSinglyLinkedListRemove10000(b *testing.B) {
 func BenchmarkSinglyLinkedListRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	list := New[int]()
+	list := singlylinkedlist.New[int]()
 	for n := 0; n < size; n++ {
 		list.Add(n)
 	}

--- a/maps/hashbidimap/hashbidimap_test.go
+++ b/maps/hashbidimap/hashbidimap_test.go
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package hashbidimap
+package hashbidimap_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/maps/hashbidimap"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestMapPut(t *testing.T) {
-	m := New[int, string]()
+	m := hashbidimap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -51,7 +52,7 @@ func TestMapPut(t *testing.T) {
 }
 
 func TestMapRemove(t *testing.T) {
-	m := New[int, string]()
+	m := hashbidimap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -110,7 +111,7 @@ func TestMapRemove(t *testing.T) {
 }
 
 func TestMapGetKey(t *testing.T) {
-	m := New[int, string]()
+	m := hashbidimap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -142,7 +143,7 @@ func TestMapGetKey(t *testing.T) {
 }
 
 func TestMapSerialization(t *testing.T) {
-	m := New[string, float64]()
+	m := hashbidimap.New[string, float64]()
 	m.Put("a", 1.0)
 	m.Put("b", 2.0)
 	m.Put("c", 3.0)
@@ -179,14 +180,14 @@ func TestMapSerialization(t *testing.T) {
 }
 
 func TestMapString(t *testing.T) {
-	c := New[string, int]()
+	c := hashbidimap.New[string, int]()
 	c.Put("a", 1)
 	if !strings.HasPrefix(c.String(), "HashBidiMap") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkGet(b *testing.B, m *Map[int, int], size int) {
+func benchmarkGet(b *testing.B, m *hashbidimap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Get(n)
@@ -194,7 +195,7 @@ func benchmarkGet(b *testing.B, m *Map[int, int], size int) {
 	}
 }
 
-func benchmarkPut(b *testing.B, m *Map[int, int], size int) {
+func benchmarkPut(b *testing.B, m *hashbidimap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Put(n, n)
@@ -202,7 +203,7 @@ func benchmarkPut(b *testing.B, m *Map[int, int], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, m *Map[int, int], size int) {
+func benchmarkRemove(b *testing.B, m *hashbidimap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Remove(n)
@@ -213,7 +214,7 @@ func benchmarkRemove(b *testing.B, m *Map[int, int], size int) {
 func BenchmarkHashBidiMapGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -224,7 +225,7 @@ func BenchmarkHashBidiMapGet100(b *testing.B) {
 func BenchmarkHashBidiMapGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -235,7 +236,7 @@ func BenchmarkHashBidiMapGet1000(b *testing.B) {
 func BenchmarkHashBidiMapGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -246,7 +247,7 @@ func BenchmarkHashBidiMapGet10000(b *testing.B) {
 func BenchmarkHashBidiMapGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -257,7 +258,7 @@ func BenchmarkHashBidiMapGet100000(b *testing.B) {
 func BenchmarkHashBidiMapPut100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	b.StartTimer()
 	benchmarkPut(b, m, size)
 }
@@ -265,7 +266,7 @@ func BenchmarkHashBidiMapPut100(b *testing.B) {
 func BenchmarkHashBidiMapPut1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -276,7 +277,7 @@ func BenchmarkHashBidiMapPut1000(b *testing.B) {
 func BenchmarkHashBidiMapPut10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -287,7 +288,7 @@ func BenchmarkHashBidiMapPut10000(b *testing.B) {
 func BenchmarkHashBidiMapPut100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -298,7 +299,7 @@ func BenchmarkHashBidiMapPut100000(b *testing.B) {
 func BenchmarkHashBidiMapRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -309,7 +310,7 @@ func BenchmarkHashBidiMapRemove100(b *testing.B) {
 func BenchmarkHashBidiMapRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -320,7 +321,7 @@ func BenchmarkHashBidiMapRemove1000(b *testing.B) {
 func BenchmarkHashBidiMapRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -331,7 +332,7 @@ func BenchmarkHashBidiMapRemove10000(b *testing.B) {
 func BenchmarkHashBidiMapRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := hashbidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}

--- a/maps/hashmap/hashmap_test.go
+++ b/maps/hashmap/hashmap_test.go
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package hashmap
+package hashmap_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/maps/hashmap"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestMapPut(t *testing.T) {
-	m := New[int, string]()
+	m := hashmap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -51,7 +52,7 @@ func TestMapPut(t *testing.T) {
 }
 
 func TestMapRemove(t *testing.T) {
-	m := New[int, string]()
+	m := hashmap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -110,7 +111,7 @@ func TestMapRemove(t *testing.T) {
 }
 
 func TestMapSerialization(t *testing.T) {
-	m := New[string, float64]()
+	m := hashmap.New[string, float64]()
 	m.Put("a", 1.0)
 	m.Put("b", 2.0)
 	m.Put("c", 3.0)
@@ -147,14 +148,14 @@ func TestMapSerialization(t *testing.T) {
 }
 
 func TestMapString(t *testing.T) {
-	c := New[string, int]()
+	c := hashmap.New[string, int]()
 	c.Put("a", 1)
 	if !strings.HasPrefix(c.String(), "HashMap") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkGet(b *testing.B, m *Map[int, int], size int) {
+func benchmarkGet(b *testing.B, m *hashmap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Get(n)
@@ -162,7 +163,7 @@ func benchmarkGet(b *testing.B, m *Map[int, int], size int) {
 	}
 }
 
-func benchmarkPut(b *testing.B, m *Map[int, int], size int) {
+func benchmarkPut(b *testing.B, m *hashmap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Put(n, n)
@@ -170,7 +171,7 @@ func benchmarkPut(b *testing.B, m *Map[int, int], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, m *Map[int, int], size int) {
+func benchmarkRemove(b *testing.B, m *hashmap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Remove(n)
@@ -181,7 +182,7 @@ func benchmarkRemove(b *testing.B, m *Map[int, int], size int) {
 func BenchmarkHashMapGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -192,7 +193,7 @@ func BenchmarkHashMapGet100(b *testing.B) {
 func BenchmarkHashMapGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -203,7 +204,7 @@ func BenchmarkHashMapGet1000(b *testing.B) {
 func BenchmarkHashMapGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -214,7 +215,7 @@ func BenchmarkHashMapGet10000(b *testing.B) {
 func BenchmarkHashMapGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -225,7 +226,7 @@ func BenchmarkHashMapGet100000(b *testing.B) {
 func BenchmarkHashMapPut100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	b.StartTimer()
 	benchmarkPut(b, m, size)
 }
@@ -233,7 +234,7 @@ func BenchmarkHashMapPut100(b *testing.B) {
 func BenchmarkHashMapPut1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -244,7 +245,7 @@ func BenchmarkHashMapPut1000(b *testing.B) {
 func BenchmarkHashMapPut10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -255,7 +256,7 @@ func BenchmarkHashMapPut10000(b *testing.B) {
 func BenchmarkHashMapPut100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -266,7 +267,7 @@ func BenchmarkHashMapPut100000(b *testing.B) {
 func BenchmarkHashMapRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -277,7 +278,7 @@ func BenchmarkHashMapRemove100(b *testing.B) {
 func BenchmarkHashMapRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -288,7 +289,7 @@ func BenchmarkHashMapRemove1000(b *testing.B) {
 func BenchmarkHashMapRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -299,7 +300,7 @@ func BenchmarkHashMapRemove10000(b *testing.B) {
 func BenchmarkHashMapRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := hashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}

--- a/maps/linkedhashmap/linkedhashmap_test.go
+++ b/maps/linkedhashmap/linkedhashmap_test.go
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package linkedhashmap
+package linkedhashmap_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/maps/linkedhashmap"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestMapPut(t *testing.T) {
-	m := New[int, string]()
+	m := linkedhashmap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -51,7 +52,7 @@ func TestMapPut(t *testing.T) {
 }
 
 func TestMapRemove(t *testing.T) {
-	m := New[int, string]()
+	m := linkedhashmap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -110,7 +111,7 @@ func TestMapRemove(t *testing.T) {
 }
 
 func TestMapEach(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	m.Put("c", 1)
 	m.Put("a", 2)
 	m.Put("b", 3)
@@ -140,7 +141,7 @@ func TestMapEach(t *testing.T) {
 }
 
 func TestMapMap(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -162,7 +163,7 @@ func TestMapMap(t *testing.T) {
 }
 
 func TestMapSelect(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("b", 1)
 	m.Put("a", 2)
@@ -181,7 +182,7 @@ func TestMapSelect(t *testing.T) {
 }
 
 func TestMapAny(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -200,7 +201,7 @@ func TestMapAny(t *testing.T) {
 }
 
 func TestMapAll(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -219,7 +220,7 @@ func TestMapAll(t *testing.T) {
 }
 
 func TestMapFind(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -238,7 +239,7 @@ func TestMapFind(t *testing.T) {
 }
 
 func TestMapChaining(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -262,7 +263,7 @@ func TestMapChaining(t *testing.T) {
 }
 
 func TestMapIteratorNextOnEmpty(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	it := m.Iterator()
 	it = m.Iterator()
 	for it.Next() {
@@ -271,7 +272,7 @@ func TestMapIteratorNextOnEmpty(t *testing.T) {
 }
 
 func TestMapIteratorPrevOnEmpty(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	it := m.Iterator()
 	it = m.Iterator()
 	for it.Prev() {
@@ -280,7 +281,7 @@ func TestMapIteratorPrevOnEmpty(t *testing.T) {
 }
 
 func TestMapIteratorNext(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	m.Put("c", 1)
 	m.Put("a", 2)
 	m.Put("b", 3)
@@ -317,7 +318,7 @@ func TestMapIteratorNext(t *testing.T) {
 }
 
 func TestMapIteratorPrev(t *testing.T) {
-	m := New[string, int]()
+	m := linkedhashmap.New[string, int]()
 	m.Put("c", 1)
 	m.Put("a", 2)
 	m.Put("b", 3)
@@ -356,7 +357,7 @@ func TestMapIteratorPrev(t *testing.T) {
 }
 
 func TestMapIteratorBegin(t *testing.T) {
-	m := New[int, string]()
+	m := linkedhashmap.New[int, string]()
 	it := m.Iterator()
 	it.Begin()
 	m.Put(3, "c")
@@ -372,7 +373,7 @@ func TestMapIteratorBegin(t *testing.T) {
 }
 
 func TestMapIteratorEnd(t *testing.T) {
-	m := New[int, string]()
+	m := linkedhashmap.New[int, string]()
 	it := m.Iterator()
 	m.Put(3, "c")
 	m.Put(1, "a")
@@ -385,7 +386,7 @@ func TestMapIteratorEnd(t *testing.T) {
 }
 
 func TestMapIteratorFirst(t *testing.T) {
-	m := New[int, string]()
+	m := linkedhashmap.New[int, string]()
 	m.Put(3, "c")
 	m.Put(1, "a")
 	m.Put(2, "b")
@@ -399,7 +400,7 @@ func TestMapIteratorFirst(t *testing.T) {
 }
 
 func TestMapIteratorLast(t *testing.T) {
-	m := New[int, string]()
+	m := linkedhashmap.New[int, string]()
 	m.Put(3, "c")
 	m.Put(1, "a")
 	m.Put(2, "b")
@@ -420,7 +421,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		m := New[int, string]()
+		m := linkedhashmap.New[int, string]()
 		it := m.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty map")
@@ -429,7 +430,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		m := New[int, string]()
+		m := linkedhashmap.New[int, string]()
 		m.Put(0, "xx")
 		m.Put(1, "yy")
 		it := m.Iterator()
@@ -440,7 +441,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		m := New[int, string]()
+		m := linkedhashmap.New[int, string]()
 		m.Put(0, "aa")
 		m.Put(1, "bb")
 		m.Put(2, "cc")
@@ -472,7 +473,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		m := New[int, string]()
+		m := linkedhashmap.New[int, string]()
 		it := m.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -482,7 +483,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		m := New[int, string]()
+		m := linkedhashmap.New[int, string]()
 		m.Put(0, "xx")
 		m.Put(1, "yy")
 		it := m.Iterator()
@@ -494,7 +495,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		m := New[int, string]()
+		m := linkedhashmap.New[int, string]()
 		m.Put(0, "aa")
 		m.Put(1, "bb")
 		m.Put(2, "cc")
@@ -520,7 +521,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 func TestMapSerialization(t *testing.T) {
 	for i := 0; i < 10; i++ {
-		original := New[string, string]()
+		original := linkedhashmap.New[string, string]()
 		original.Put("d", "4")
 		original.Put("e", "5")
 		original.Put("c", "3")
@@ -532,7 +533,7 @@ func TestMapSerialization(t *testing.T) {
 			t.Errorf("Got error %v", err)
 		}
 
-		deserialized := New[string, string]()
+		deserialized := linkedhashmap.New[string, string]()
 		err = deserialized.FromJSON(serialized)
 		if err != nil {
 			t.Errorf("Got error %v", err)
@@ -549,7 +550,7 @@ func TestMapSerialization(t *testing.T) {
 		})
 	}
 
-	m := New[string, float64]()
+	m := linkedhashmap.New[string, float64]()
 	m.Put("a", 1.0)
 	m.Put("b", 2.0)
 	m.Put("c", 3.0)
@@ -566,14 +567,14 @@ func TestMapSerialization(t *testing.T) {
 }
 
 func TestMapString(t *testing.T) {
-	c := New[string, int]()
+	c := linkedhashmap.New[string, int]()
 	c.Put("a", 1)
 	if !strings.HasPrefix(c.String(), "LinkedHashMap") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkGet(b *testing.B, m *Map[int, int], size int) {
+func benchmarkGet(b *testing.B, m *linkedhashmap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Get(n)
@@ -581,7 +582,7 @@ func benchmarkGet(b *testing.B, m *Map[int, int], size int) {
 	}
 }
 
-func benchmarkPut(b *testing.B, m *Map[int, int], size int) {
+func benchmarkPut(b *testing.B, m *linkedhashmap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Put(n, n)
@@ -589,7 +590,7 @@ func benchmarkPut(b *testing.B, m *Map[int, int], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, m *Map[int, int], size int) {
+func benchmarkRemove(b *testing.B, m *linkedhashmap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Remove(n)
@@ -600,7 +601,7 @@ func benchmarkRemove(b *testing.B, m *Map[int, int], size int) {
 func BenchmarkTreeMapGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -611,7 +612,7 @@ func BenchmarkTreeMapGet100(b *testing.B) {
 func BenchmarkTreeMapGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -622,7 +623,7 @@ func BenchmarkTreeMapGet1000(b *testing.B) {
 func BenchmarkTreeMapGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -633,7 +634,7 @@ func BenchmarkTreeMapGet10000(b *testing.B) {
 func BenchmarkTreeMapGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -644,7 +645,7 @@ func BenchmarkTreeMapGet100000(b *testing.B) {
 func BenchmarkTreeMapPut100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	b.StartTimer()
 	benchmarkPut(b, m, size)
 }
@@ -652,7 +653,7 @@ func BenchmarkTreeMapPut100(b *testing.B) {
 func BenchmarkTreeMapPut1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -663,7 +664,7 @@ func BenchmarkTreeMapPut1000(b *testing.B) {
 func BenchmarkTreeMapPut10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -674,7 +675,7 @@ func BenchmarkTreeMapPut10000(b *testing.B) {
 func BenchmarkTreeMapPut100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -685,7 +686,7 @@ func BenchmarkTreeMapPut100000(b *testing.B) {
 func BenchmarkTreeMapRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -696,7 +697,7 @@ func BenchmarkTreeMapRemove100(b *testing.B) {
 func BenchmarkTreeMapRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -707,7 +708,7 @@ func BenchmarkTreeMapRemove1000(b *testing.B) {
 func BenchmarkTreeMapRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -718,7 +719,7 @@ func BenchmarkTreeMapRemove10000(b *testing.B) {
 func BenchmarkTreeMapRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := linkedhashmap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}

--- a/maps/treebidimap/treebidimap_test.go
+++ b/maps/treebidimap/treebidimap_test.go
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package treebidimap
+package treebidimap_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/maps/treebidimap"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestMapPut(t *testing.T) {
-	m := New[int, string]()
+	m := treebidimap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -51,7 +52,7 @@ func TestMapPut(t *testing.T) {
 }
 
 func TestMapRemove(t *testing.T) {
-	m := New[int, string]()
+	m := treebidimap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -110,7 +111,7 @@ func TestMapRemove(t *testing.T) {
 }
 
 func TestMapGetKey(t *testing.T) {
-	m := New[int, string]()
+	m := treebidimap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -161,7 +162,7 @@ func sameElements(a []interface{}, b []interface{}) bool {
 }
 
 func TestMapEach(t *testing.T) {
-	m := New[string, int]()
+	m := treebidimap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -191,7 +192,7 @@ func TestMapEach(t *testing.T) {
 }
 
 func TestMapMap(t *testing.T) {
-	m := New[string, int]()
+	m := treebidimap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -213,7 +214,7 @@ func TestMapMap(t *testing.T) {
 }
 
 func TestMapSelect(t *testing.T) {
-	m := New[string, int]()
+	m := treebidimap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -232,7 +233,7 @@ func TestMapSelect(t *testing.T) {
 }
 
 func TestMapAny(t *testing.T) {
-	m := New[string, int]()
+	m := treebidimap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -251,7 +252,7 @@ func TestMapAny(t *testing.T) {
 }
 
 func TestMapAll(t *testing.T) {
-	m := New[string, int]()
+	m := treebidimap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -270,7 +271,7 @@ func TestMapAll(t *testing.T) {
 }
 
 func TestMapFind(t *testing.T) {
-	m := New[string, int]()
+	m := treebidimap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -289,7 +290,7 @@ func TestMapFind(t *testing.T) {
 }
 
 func TestMapChaining(t *testing.T) {
-	m := New[string, int]()
+	m := treebidimap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -313,7 +314,7 @@ func TestMapChaining(t *testing.T) {
 }
 
 func TestMapIteratorNextOnEmpty(t *testing.T) {
-	m := New[string, string]()
+	m := treebidimap.New[string, string]()
 	it := m.Iterator()
 	it = m.Iterator()
 	for it.Next() {
@@ -322,7 +323,7 @@ func TestMapIteratorNextOnEmpty(t *testing.T) {
 }
 
 func TestMapIteratorPrevOnEmpty(t *testing.T) {
-	m := New[string, string]()
+	m := treebidimap.New[string, string]()
 	it := m.Iterator()
 	it = m.Iterator()
 	for it.Prev() {
@@ -331,7 +332,7 @@ func TestMapIteratorPrevOnEmpty(t *testing.T) {
 }
 
 func TestMapIteratorNext(t *testing.T) {
-	m := New[string, int]()
+	m := treebidimap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -368,7 +369,7 @@ func TestMapIteratorNext(t *testing.T) {
 }
 
 func TestMapIteratorPrev(t *testing.T) {
-	m := New[string, int]()
+	m := treebidimap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -407,7 +408,7 @@ func TestMapIteratorPrev(t *testing.T) {
 }
 
 func TestMapIteratorBegin(t *testing.T) {
-	m := New[int, string]()
+	m := treebidimap.New[int, string]()
 	it := m.Iterator()
 	it.Begin()
 	m.Put(3, "c")
@@ -423,7 +424,7 @@ func TestMapIteratorBegin(t *testing.T) {
 }
 
 func TestMapIteratorEnd(t *testing.T) {
-	m := New[int, string]()
+	m := treebidimap.New[int, string]()
 	it := m.Iterator()
 	m.Put(3, "c")
 	m.Put(1, "a")
@@ -436,7 +437,7 @@ func TestMapIteratorEnd(t *testing.T) {
 }
 
 func TestMapIteratorFirst(t *testing.T) {
-	m := New[int, string]()
+	m := treebidimap.New[int, string]()
 	m.Put(3, "c")
 	m.Put(1, "a")
 	m.Put(2, "b")
@@ -450,7 +451,7 @@ func TestMapIteratorFirst(t *testing.T) {
 }
 
 func TestMapIteratorLast(t *testing.T) {
-	m := New[int, string]()
+	m := treebidimap.New[int, string]()
 	m.Put(3, "c")
 	m.Put(1, "a")
 	m.Put(2, "b")
@@ -471,7 +472,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		m := New[int, string]()
+		m := treebidimap.New[int, string]()
 		it := m.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty map")
@@ -480,7 +481,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		m := New[int, string]()
+		m := treebidimap.New[int, string]()
 		m.Put(0, "xx")
 		m.Put(1, "yy")
 		it := m.Iterator()
@@ -491,7 +492,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		m := New[int, string]()
+		m := treebidimap.New[int, string]()
 		m.Put(0, "aa")
 		m.Put(1, "bb")
 		m.Put(2, "cc")
@@ -523,7 +524,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		m := New[int, string]()
+		m := treebidimap.New[int, string]()
 		it := m.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -533,7 +534,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		m := New[int, string]()
+		m := treebidimap.New[int, string]()
 		m.Put(0, "xx")
 		m.Put(1, "yy")
 		it := m.Iterator()
@@ -545,7 +546,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		m := New[int, string]()
+		m := treebidimap.New[int, string]()
 		m.Put(0, "aa")
 		m.Put(1, "bb")
 		m.Put(2, "cc")
@@ -571,7 +572,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 func TestMapSerialization(t *testing.T) {
 	for i := 0; i < 10; i++ {
-		original := New[string, string]()
+		original := treebidimap.New[string, string]()
 		original.Put("d", "4")
 		original.Put("e", "5")
 		original.Put("c", "3")
@@ -583,7 +584,7 @@ func TestMapSerialization(t *testing.T) {
 			t.Errorf("Got error %v", err)
 		}
 
-		deserialized := New[string, string]()
+		deserialized := treebidimap.New[string, string]()
 		err = deserialized.FromJSON(serialized)
 		if err != nil {
 			t.Errorf("Got error %v", err)
@@ -600,7 +601,7 @@ func TestMapSerialization(t *testing.T) {
 		})
 	}
 
-	m := New[string, float64]()
+	m := treebidimap.New[string, float64]()
 	m.Put("a", 1.0)
 	m.Put("b", 2.0)
 	m.Put("c", 3.0)
@@ -617,14 +618,14 @@ func TestMapSerialization(t *testing.T) {
 }
 
 func TestMapString(t *testing.T) {
-	c := New[string, string]()
+	c := treebidimap.New[string, string]()
 	c.Put("a", "a")
 	if !strings.HasPrefix(c.String(), "TreeBidiMap") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkGet(b *testing.B, m *Map[int, int], size int) {
+func benchmarkGet(b *testing.B, m *treebidimap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Get(n)
@@ -632,7 +633,7 @@ func benchmarkGet(b *testing.B, m *Map[int, int], size int) {
 	}
 }
 
-func benchmarkPut(b *testing.B, m *Map[int, int], size int) {
+func benchmarkPut(b *testing.B, m *treebidimap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Put(n, n)
@@ -640,7 +641,7 @@ func benchmarkPut(b *testing.B, m *Map[int, int], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, m *Map[int, int], size int) {
+func benchmarkRemove(b *testing.B, m *treebidimap.Map[int, int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Remove(n)
@@ -651,7 +652,7 @@ func benchmarkRemove(b *testing.B, m *Map[int, int], size int) {
 func BenchmarkTreeBidiMapGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -662,7 +663,7 @@ func BenchmarkTreeBidiMapGet100(b *testing.B) {
 func BenchmarkTreeBidiMapGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -673,7 +674,7 @@ func BenchmarkTreeBidiMapGet1000(b *testing.B) {
 func BenchmarkTreeBidiMapGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -684,7 +685,7 @@ func BenchmarkTreeBidiMapGet10000(b *testing.B) {
 func BenchmarkTreeBidiMapGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -695,7 +696,7 @@ func BenchmarkTreeBidiMapGet100000(b *testing.B) {
 func BenchmarkTreeBidiMapPut100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	b.StartTimer()
 	benchmarkPut(b, m, size)
 }
@@ -703,7 +704,7 @@ func BenchmarkTreeBidiMapPut100(b *testing.B) {
 func BenchmarkTreeBidiMapPut1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -714,7 +715,7 @@ func BenchmarkTreeBidiMapPut1000(b *testing.B) {
 func BenchmarkTreeBidiMapPut10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -725,7 +726,7 @@ func BenchmarkTreeBidiMapPut10000(b *testing.B) {
 func BenchmarkTreeBidiMapPut100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -736,7 +737,7 @@ func BenchmarkTreeBidiMapPut100000(b *testing.B) {
 func BenchmarkTreeBidiMapRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -747,7 +748,7 @@ func BenchmarkTreeBidiMapRemove100(b *testing.B) {
 func BenchmarkTreeBidiMapRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -758,7 +759,7 @@ func BenchmarkTreeBidiMapRemove1000(b *testing.B) {
 func BenchmarkTreeBidiMapRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}
@@ -769,7 +770,7 @@ func BenchmarkTreeBidiMapRemove10000(b *testing.B) {
 func BenchmarkTreeBidiMapRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, int]()
+	m := treebidimap.New[int, int]()
 	for n := 0; n < size; n++ {
 		m.Put(n, n)
 	}

--- a/maps/treemap/treemap_test.go
+++ b/maps/treemap/treemap_test.go
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package treemap
+package treemap_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/maps/treemap"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestMapPut(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -51,7 +52,7 @@ func TestMapPut(t *testing.T) {
 }
 
 func TestMapMin(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 
 	if k, v, ok := m.Min(); k != 0 || v != "" || ok {
 		t.Errorf("Got %v->%v->%v expected %v->%v-%v", k, v, ok, 0, "", false)
@@ -80,7 +81,7 @@ func TestMapMin(t *testing.T) {
 }
 
 func TestMapMax(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 
 	if k, v, ok := m.Max(); k != 0 || v != "" || ok {
 		t.Errorf("Got %v->%v->%v expected %v->%v-%v", k, v, ok, 0, "", false)
@@ -109,7 +110,7 @@ func TestMapMax(t *testing.T) {
 }
 
 func TestMapClear(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -124,7 +125,7 @@ func TestMapClear(t *testing.T) {
 }
 
 func TestMapRemove(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 	m.Put(5, "e")
 	m.Put(6, "f")
 	m.Put(7, "g")
@@ -183,7 +184,7 @@ func TestMapRemove(t *testing.T) {
 }
 
 func TestMapFloor(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 	m.Put(7, "g")
 	m.Put(3, "c")
 	m.Put(1, "a")
@@ -210,7 +211,7 @@ func TestMapFloor(t *testing.T) {
 }
 
 func TestMapCeiling(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 	m.Put(7, "g")
 	m.Put(3, "c")
 	m.Put(1, "a")
@@ -237,7 +238,7 @@ func TestMapCeiling(t *testing.T) {
 }
 
 func TestMapEach(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -267,7 +268,7 @@ func TestMapEach(t *testing.T) {
 }
 
 func TestMapMap(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -289,7 +290,7 @@ func TestMapMap(t *testing.T) {
 }
 
 func TestMapSelect(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -308,7 +309,7 @@ func TestMapSelect(t *testing.T) {
 }
 
 func TestMapAny(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -327,7 +328,7 @@ func TestMapAny(t *testing.T) {
 }
 
 func TestMapAll(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -346,7 +347,7 @@ func TestMapAll(t *testing.T) {
 }
 
 func TestMapFind(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -365,7 +366,7 @@ func TestMapFind(t *testing.T) {
 }
 
 func TestMapChaining(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -389,7 +390,7 @@ func TestMapChaining(t *testing.T) {
 }
 
 func TestMapIteratorNextOnEmpty(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	it := m.Iterator()
 	it = m.Iterator()
 	for it.Next() {
@@ -398,7 +399,7 @@ func TestMapIteratorNextOnEmpty(t *testing.T) {
 }
 
 func TestMapIteratorPrevOnEmpty(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	it := m.Iterator()
 	it = m.Iterator()
 	for it.Prev() {
@@ -407,7 +408,7 @@ func TestMapIteratorPrevOnEmpty(t *testing.T) {
 }
 
 func TestMapIteratorNext(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -444,7 +445,7 @@ func TestMapIteratorNext(t *testing.T) {
 }
 
 func TestMapIteratorPrev(t *testing.T) {
-	m := New[string, int]()
+	m := treemap.New[string, int]()
 	m.Put("c", 3)
 	m.Put("a", 1)
 	m.Put("b", 2)
@@ -483,7 +484,7 @@ func TestMapIteratorPrev(t *testing.T) {
 }
 
 func TestMapIteratorBegin(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 	it := m.Iterator()
 	it.Begin()
 	m.Put(3, "c")
@@ -499,7 +500,7 @@ func TestMapIteratorBegin(t *testing.T) {
 }
 
 func TestMapIteratorEnd(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 	it := m.Iterator()
 	m.Put(3, "c")
 	m.Put(1, "a")
@@ -512,7 +513,7 @@ func TestMapIteratorEnd(t *testing.T) {
 }
 
 func TestMapIteratorFirst(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 	m.Put(3, "c")
 	m.Put(1, "a")
 	m.Put(2, "b")
@@ -526,7 +527,7 @@ func TestMapIteratorFirst(t *testing.T) {
 }
 
 func TestMapIteratorLast(t *testing.T) {
-	m := New[int, string]()
+	m := treemap.New[int, string]()
 	m.Put(3, "c")
 	m.Put(1, "a")
 	m.Put(2, "b")
@@ -547,7 +548,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		m := New[int, string]()
+		m := treemap.New[int, string]()
 		it := m.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty map")
@@ -556,7 +557,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		m := New[int, string]()
+		m := treemap.New[int, string]()
 		m.Put(0, "xx")
 		m.Put(1, "yy")
 		it := m.Iterator()
@@ -567,7 +568,7 @@ func TestMapIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		m := New[int, string]()
+		m := treemap.New[int, string]()
 		m.Put(0, "aa")
 		m.Put(1, "bb")
 		m.Put(2, "cc")
@@ -599,7 +600,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		m := New[int, string]()
+		m := treemap.New[int, string]()
 		it := m.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -609,7 +610,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		m := New[int, string]()
+		m := treemap.New[int, string]()
 		m.Put(0, "xx")
 		m.Put(1, "yy")
 		it := m.Iterator()
@@ -621,7 +622,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		m := New[int, string]()
+		m := treemap.New[int, string]()
 		m.Put(0, "aa")
 		m.Put(1, "bb")
 		m.Put(2, "cc")
@@ -647,7 +648,7 @@ func TestMapIteratorPrevTo(t *testing.T) {
 
 func TestMapSerialization(t *testing.T) {
 	for i := 0; i < 10; i++ {
-		original := New[string, string]()
+		original := treemap.New[string, string]()
 		original.Put("d", "4")
 		original.Put("e", "5")
 		original.Put("c", "3")
@@ -662,7 +663,7 @@ func TestMapSerialization(t *testing.T) {
 		}
 		assertSerialization(original, "B", t)
 
-		deserialized := New[string, string]()
+		deserialized := treemap.New[string, string]()
 		err = deserialized.FromJSON(serialized)
 		if err != nil {
 			t.Errorf("Got error %v", err)
@@ -670,7 +671,7 @@ func TestMapSerialization(t *testing.T) {
 		assertSerialization(deserialized, "C", t)
 	}
 
-	m := New[string, float64]()
+	m := treemap.New[string, float64]()
 	m.Put("a", 1.0)
 	m.Put("b", 2.0)
 	m.Put("c", 3.0)
@@ -687,7 +688,7 @@ func TestMapSerialization(t *testing.T) {
 }
 
 func TestMapString(t *testing.T) {
-	c := New[string, int]()
+	c := treemap.New[string, int]()
 	c.Put("a", 1)
 	if !strings.HasPrefix(c.String(), "TreeMap") {
 		t.Errorf("String should start with container name")
@@ -695,7 +696,7 @@ func TestMapString(t *testing.T) {
 }
 
 // noinspection GoBoolExpressions
-func assertSerialization(m *Map[string, string], txt string, t *testing.T) {
+func assertSerialization(m *treemap.Map[string, string], txt string, t *testing.T) {
 	if actualValue := m.Keys(); false ||
 		actualValue[0] != "a" ||
 		actualValue[1] != "b" ||
@@ -717,7 +718,7 @@ func assertSerialization(m *Map[string, string], txt string, t *testing.T) {
 	}
 }
 
-func benchmarkGet(b *testing.B, m *Map[int, struct{}], size int) {
+func benchmarkGet(b *testing.B, m *treemap.Map[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Get(n)
@@ -725,7 +726,7 @@ func benchmarkGet(b *testing.B, m *Map[int, struct{}], size int) {
 	}
 }
 
-func benchmarkPut(b *testing.B, m *Map[int, struct{}], size int) {
+func benchmarkPut(b *testing.B, m *treemap.Map[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Put(n, struct{}{})
@@ -733,7 +734,7 @@ func benchmarkPut(b *testing.B, m *Map[int, struct{}], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, m *Map[int, struct{}], size int) {
+func benchmarkRemove(b *testing.B, m *treemap.Map[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			m.Remove(n)
@@ -744,7 +745,7 @@ func benchmarkRemove(b *testing.B, m *Map[int, struct{}], size int) {
 func BenchmarkTreeMapGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}
@@ -755,7 +756,7 @@ func BenchmarkTreeMapGet100(b *testing.B) {
 func BenchmarkTreeMapGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}
@@ -766,7 +767,7 @@ func BenchmarkTreeMapGet1000(b *testing.B) {
 func BenchmarkTreeMapGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}
@@ -777,7 +778,7 @@ func BenchmarkTreeMapGet10000(b *testing.B) {
 func BenchmarkTreeMapGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}
@@ -788,7 +789,7 @@ func BenchmarkTreeMapGet100000(b *testing.B) {
 func BenchmarkTreeMapPut100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	b.StartTimer()
 	benchmarkPut(b, m, size)
 }
@@ -796,7 +797,7 @@ func BenchmarkTreeMapPut100(b *testing.B) {
 func BenchmarkTreeMapPut1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}
@@ -807,7 +808,7 @@ func BenchmarkTreeMapPut1000(b *testing.B) {
 func BenchmarkTreeMapPut10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}
@@ -818,7 +819,7 @@ func BenchmarkTreeMapPut10000(b *testing.B) {
 func BenchmarkTreeMapPut100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}
@@ -829,7 +830,7 @@ func BenchmarkTreeMapPut100000(b *testing.B) {
 func BenchmarkTreeMapRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}
@@ -840,7 +841,7 @@ func BenchmarkTreeMapRemove100(b *testing.B) {
 func BenchmarkTreeMapRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}
@@ -851,7 +852,7 @@ func BenchmarkTreeMapRemove1000(b *testing.B) {
 func BenchmarkTreeMapRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}
@@ -862,7 +863,7 @@ func BenchmarkTreeMapRemove10000(b *testing.B) {
 func BenchmarkTreeMapRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	m := New[int, struct{}]()
+	m := treemap.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		m.Put(n, struct{}{})
 	}

--- a/queues/arrayqueue/arrayqueue_test.go
+++ b/queues/arrayqueue/arrayqueue_test.go
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package arrayqueue
+package arrayqueue_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/queues/arrayqueue"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestQueueEnqueue(t *testing.T) {
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	if actualValue := queue.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
 	}
@@ -36,7 +37,7 @@ func TestQueueEnqueue(t *testing.T) {
 }
 
 func TestQueuePeek(t *testing.T) {
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	if actualValue, ok := queue.Peek(); actualValue != 0 || ok {
 		t.Errorf("Got %v expected %v", actualValue, nil)
 	}
@@ -49,7 +50,7 @@ func TestQueuePeek(t *testing.T) {
 }
 
 func TestQueueDequeue(t *testing.T) {
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	queue.Enqueue(1)
 	queue.Enqueue(2)
 	queue.Enqueue(3)
@@ -75,7 +76,7 @@ func TestQueueDequeue(t *testing.T) {
 }
 
 func TestQueueIteratorOnEmpty(t *testing.T) {
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	it := queue.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty queue")
@@ -83,7 +84,7 @@ func TestQueueIteratorOnEmpty(t *testing.T) {
 }
 
 func TestQueueIteratorNext(t *testing.T) {
-	queue := New[string]()
+	queue := arrayqueue.New[string]()
 	queue.Enqueue("a")
 	queue.Enqueue("b")
 	queue.Enqueue("c")
@@ -126,7 +127,7 @@ func TestQueueIteratorNext(t *testing.T) {
 }
 
 func TestQueueIteratorPrev(t *testing.T) {
-	queue := New[string]()
+	queue := arrayqueue.New[string]()
 	queue.Enqueue("a")
 	queue.Enqueue("b")
 	queue.Enqueue("c")
@@ -165,7 +166,7 @@ func TestQueueIteratorPrev(t *testing.T) {
 }
 
 func TestQueueIteratorBegin(t *testing.T) {
-	queue := New[string]()
+	queue := arrayqueue.New[string]()
 	it := queue.Iterator()
 	it.Begin()
 	queue.Enqueue("a")
@@ -181,7 +182,7 @@ func TestQueueIteratorBegin(t *testing.T) {
 }
 
 func TestQueueIteratorEnd(t *testing.T) {
-	queue := New[string]()
+	queue := arrayqueue.New[string]()
 	it := queue.Iterator()
 
 	if index := it.Index(); index != -1 {
@@ -208,7 +209,7 @@ func TestQueueIteratorEnd(t *testing.T) {
 }
 
 func TestQueueIteratorFirst(t *testing.T) {
-	queue := New[string]()
+	queue := arrayqueue.New[string]()
 	it := queue.Iterator()
 	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -225,7 +226,7 @@ func TestQueueIteratorFirst(t *testing.T) {
 }
 
 func TestQueueIteratorLast(t *testing.T) {
-	queue := New[string]()
+	queue := arrayqueue.New[string]()
 	it := queue.Iterator()
 	if actualValue, expectedValue := it.Last(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -249,7 +250,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		queue := New[string]()
+		queue := arrayqueue.New[string]()
 		it := queue.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty queue")
@@ -258,7 +259,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		queue := New[string]()
+		queue := arrayqueue.New[string]()
 		queue.Enqueue("xx")
 		queue.Enqueue("yy")
 		it := queue.Iterator()
@@ -269,7 +270,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		queue := New[string]()
+		queue := arrayqueue.New[string]()
 		queue.Enqueue("aa")
 		queue.Enqueue("bb")
 		queue.Enqueue("cc")
@@ -301,7 +302,7 @@ func TestQueueIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		queue := New[string]()
+		queue := arrayqueue.New[string]()
 		it := queue.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -311,7 +312,7 @@ func TestQueueIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		queue := New[string]()
+		queue := arrayqueue.New[string]()
 		queue.Enqueue("xx")
 		queue.Enqueue("yy")
 		it := queue.Iterator()
@@ -323,7 +324,7 @@ func TestQueueIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		queue := New[string]()
+		queue := arrayqueue.New[string]()
 		queue.Enqueue("aa")
 		queue.Enqueue("bb")
 		queue.Enqueue("cc")
@@ -348,7 +349,7 @@ func TestQueueIteratorPrevTo(t *testing.T) {
 }
 
 func TestQueueSerialization(t *testing.T) {
-	queue := New[string]()
+	queue := arrayqueue.New[string]()
 	queue.Enqueue("a")
 	queue.Enqueue("b")
 	queue.Enqueue("c")
@@ -385,14 +386,14 @@ func TestQueueSerialization(t *testing.T) {
 }
 
 func TestQueueString(t *testing.T) {
-	c := New[int]()
+	c := arrayqueue.New[int]()
 	c.Enqueue(1)
 	if !strings.HasPrefix(c.String(), "ArrayQueue") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkEnqueue(b *testing.B, queue *Queue[int], size int) {
+func benchmarkEnqueue(b *testing.B, queue *arrayqueue.Queue[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			queue.Enqueue(n)
@@ -400,7 +401,7 @@ func benchmarkEnqueue(b *testing.B, queue *Queue[int], size int) {
 	}
 }
 
-func benchmarkDequeue(b *testing.B, queue *Queue[int], size int) {
+func benchmarkDequeue(b *testing.B, queue *arrayqueue.Queue[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			queue.Dequeue()
@@ -411,7 +412,7 @@ func benchmarkDequeue(b *testing.B, queue *Queue[int], size int) {
 func BenchmarkArrayQueueDequeue100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -422,7 +423,7 @@ func BenchmarkArrayQueueDequeue100(b *testing.B) {
 func BenchmarkArrayQueueDequeue1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -433,7 +434,7 @@ func BenchmarkArrayQueueDequeue1000(b *testing.B) {
 func BenchmarkArrayQueueDequeue10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -444,7 +445,7 @@ func BenchmarkArrayQueueDequeue10000(b *testing.B) {
 func BenchmarkArrayQueueDequeue100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -455,7 +456,7 @@ func BenchmarkArrayQueueDequeue100000(b *testing.B) {
 func BenchmarkArrayQueueEnqueue100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	b.StartTimer()
 	benchmarkEnqueue(b, queue, size)
 }
@@ -463,7 +464,7 @@ func BenchmarkArrayQueueEnqueue100(b *testing.B) {
 func BenchmarkArrayQueueEnqueue1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -474,7 +475,7 @@ func BenchmarkArrayQueueEnqueue1000(b *testing.B) {
 func BenchmarkArrayQueueEnqueue10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -485,7 +486,7 @@ func BenchmarkArrayQueueEnqueue10000(b *testing.B) {
 func BenchmarkArrayQueueEnqueue100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	queue := New[int]()
+	queue := arrayqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}

--- a/queues/circularbuffer/circularbuffer_test.go
+++ b/queues/circularbuffer/circularbuffer_test.go
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package circularbuffer
+package circularbuffer_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/queues/circularbuffer"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestQueueEnqueue(t *testing.T) {
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	if actualValue := queue.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
 	}
@@ -36,7 +37,7 @@ func TestQueueEnqueue(t *testing.T) {
 }
 
 func TestQueuePeek(t *testing.T) {
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	if actualValue, ok := queue.Peek(); actualValue != 0 || ok {
 		t.Errorf("Got %v expected %v", actualValue, nil)
 	}
@@ -55,7 +56,7 @@ func TestQueueDequeue(t *testing.T) {
 		}
 	}
 
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	assert(queue.Empty(), true)
 	assert(queue.Empty(), true)
 	assert(queue.Full(), false)
@@ -107,7 +108,7 @@ func TestQueueDequeueFull(t *testing.T) {
 		}
 	}
 
-	queue := New[int](2)
+	queue := circularbuffer.New[int](2)
 	assert(queue.Empty(), true)
 	assert(queue.Full(), false)
 	assert(queue.Size(), 0)
@@ -152,7 +153,7 @@ func TestQueueDequeueFull(t *testing.T) {
 }
 
 func TestQueueIteratorOnEmpty(t *testing.T) {
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	it := queue.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty queue")
@@ -160,7 +161,7 @@ func TestQueueIteratorOnEmpty(t *testing.T) {
 }
 
 func TestQueueIteratorNext(t *testing.T) {
-	queue := New[string](3)
+	queue := circularbuffer.New[string](3)
 	queue.Enqueue("a")
 	queue.Enqueue("b")
 	queue.Enqueue("c")
@@ -203,7 +204,7 @@ func TestQueueIteratorNext(t *testing.T) {
 }
 
 func TestQueueIteratorPrev(t *testing.T) {
-	queue := New[string](3)
+	queue := circularbuffer.New[string](3)
 	queue.Enqueue("a")
 	queue.Enqueue("b")
 	queue.Enqueue("c")
@@ -242,7 +243,7 @@ func TestQueueIteratorPrev(t *testing.T) {
 }
 
 func TestQueueIteratorBegin(t *testing.T) {
-	queue := New[string](3)
+	queue := circularbuffer.New[string](3)
 	it := queue.Iterator()
 	it.Begin()
 	queue.Enqueue("a")
@@ -258,7 +259,7 @@ func TestQueueIteratorBegin(t *testing.T) {
 }
 
 func TestQueueIteratorEnd(t *testing.T) {
-	queue := New[string](3)
+	queue := circularbuffer.New[string](3)
 	it := queue.Iterator()
 
 	if index := it.Index(); index != -1 {
@@ -285,7 +286,7 @@ func TestQueueIteratorEnd(t *testing.T) {
 }
 
 func TestQueueIteratorFirst(t *testing.T) {
-	queue := New[string](3)
+	queue := circularbuffer.New[string](3)
 	it := queue.Iterator()
 	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -302,7 +303,7 @@ func TestQueueIteratorFirst(t *testing.T) {
 }
 
 func TestQueueIteratorLast(t *testing.T) {
-	queue := New[string](3)
+	queue := circularbuffer.New[string](3)
 	it := queue.Iterator()
 	if actualValue, expectedValue := it.Last(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -326,7 +327,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		queue := New[string](3)
+		queue := circularbuffer.New[string](3)
 		it := queue.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty queue")
@@ -335,7 +336,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		queue := New[string](3)
+		queue := circularbuffer.New[string](3)
 		queue.Enqueue("xx")
 		queue.Enqueue("yy")
 		it := queue.Iterator()
@@ -346,7 +347,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		queue := New[string](3)
+		queue := circularbuffer.New[string](3)
 		queue.Enqueue("aa")
 		queue.Enqueue("bb")
 		queue.Enqueue("cc")
@@ -378,7 +379,7 @@ func TestQueueIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		queue := New[string](3)
+		queue := circularbuffer.New[string](3)
 		it := queue.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -388,7 +389,7 @@ func TestQueueIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		queue := New[string](3)
+		queue := circularbuffer.New[string](3)
 		queue.Enqueue("xx")
 		queue.Enqueue("yy")
 		it := queue.Iterator()
@@ -400,7 +401,7 @@ func TestQueueIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		queue := New[string](3)
+		queue := circularbuffer.New[string](3)
 		queue.Enqueue("aa")
 		queue.Enqueue("bb")
 		queue.Enqueue("cc")
@@ -431,7 +432,7 @@ func TestQueueIterator(t *testing.T) {
 		}
 	}
 
-	queue := New[string](2)
+	queue := circularbuffer.New[string](2)
 
 	queue.Enqueue("a")
 	queue.Enqueue("b")
@@ -483,7 +484,7 @@ func TestQueueIterator(t *testing.T) {
 }
 
 func TestQueueSerialization(t *testing.T) {
-	queue := New[string](3)
+	queue := circularbuffer.New[string](3)
 	queue.Enqueue("a")
 	queue.Enqueue("b")
 	queue.Enqueue("c")
@@ -520,14 +521,14 @@ func TestQueueSerialization(t *testing.T) {
 }
 
 func TestQueueString(t *testing.T) {
-	c := New[int](3)
+	c := circularbuffer.New[int](3)
 	c.Enqueue(1)
 	if !strings.HasPrefix(c.String(), "CircularBuffer") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkEnqueue(b *testing.B, queue *Queue[int], size int) {
+func benchmarkEnqueue(b *testing.B, queue *circularbuffer.Queue[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			queue.Enqueue(n)
@@ -535,7 +536,7 @@ func benchmarkEnqueue(b *testing.B, queue *Queue[int], size int) {
 	}
 }
 
-func benchmarkDequeue(b *testing.B, queue *Queue[int], size int) {
+func benchmarkDequeue(b *testing.B, queue *circularbuffer.Queue[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			queue.Dequeue()
@@ -546,7 +547,7 @@ func benchmarkDequeue(b *testing.B, queue *Queue[int], size int) {
 func BenchmarkArrayQueueDequeue100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -557,7 +558,7 @@ func BenchmarkArrayQueueDequeue100(b *testing.B) {
 func BenchmarkArrayQueueDequeue1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -568,7 +569,7 @@ func BenchmarkArrayQueueDequeue1000(b *testing.B) {
 func BenchmarkArrayQueueDequeue10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -579,7 +580,7 @@ func BenchmarkArrayQueueDequeue10000(b *testing.B) {
 func BenchmarkArrayQueueDequeue100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -590,7 +591,7 @@ func BenchmarkArrayQueueDequeue100000(b *testing.B) {
 func BenchmarkArrayQueueEnqueue100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	b.StartTimer()
 	benchmarkEnqueue(b, queue, size)
 }
@@ -598,7 +599,7 @@ func BenchmarkArrayQueueEnqueue100(b *testing.B) {
 func BenchmarkArrayQueueEnqueue1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -609,7 +610,7 @@ func BenchmarkArrayQueueEnqueue1000(b *testing.B) {
 func BenchmarkArrayQueueEnqueue10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -620,7 +621,7 @@ func BenchmarkArrayQueueEnqueue10000(b *testing.B) {
 func BenchmarkArrayQueueEnqueue100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	queue := New[int](3)
+	queue := circularbuffer.New[int](3)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}

--- a/queues/linkedlistqueue/linkedlistqueue_test.go
+++ b/queues/linkedlistqueue/linkedlistqueue_test.go
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package linkedlistqueue
+package linkedlistqueue_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/queues/linkedlistqueue"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestQueueEnqueue(t *testing.T) {
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	if actualValue := queue.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
 	}
@@ -36,7 +37,7 @@ func TestQueueEnqueue(t *testing.T) {
 }
 
 func TestQueuePeek(t *testing.T) {
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	if actualValue, ok := queue.Peek(); actualValue != 0 || ok {
 		t.Errorf("Got %v expected %v", actualValue, nil)
 	}
@@ -49,7 +50,7 @@ func TestQueuePeek(t *testing.T) {
 }
 
 func TestQueueDequeue(t *testing.T) {
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	queue.Enqueue(1)
 	queue.Enqueue(2)
 	queue.Enqueue(3)
@@ -75,7 +76,7 @@ func TestQueueDequeue(t *testing.T) {
 }
 
 func TestQueueIteratorOnEmpty(t *testing.T) {
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	it := queue.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty queue")
@@ -83,7 +84,7 @@ func TestQueueIteratorOnEmpty(t *testing.T) {
 }
 
 func TestQueueIteratorNext(t *testing.T) {
-	queue := New[string]()
+	queue := linkedlistqueue.New[string]()
 	queue.Enqueue("a")
 	queue.Enqueue("b")
 	queue.Enqueue("c")
@@ -126,7 +127,7 @@ func TestQueueIteratorNext(t *testing.T) {
 }
 
 func TestQueueIteratorBegin(t *testing.T) {
-	queue := New[string]()
+	queue := linkedlistqueue.New[string]()
 	it := queue.Iterator()
 	it.Begin()
 	queue.Enqueue("a")
@@ -142,7 +143,7 @@ func TestQueueIteratorBegin(t *testing.T) {
 }
 
 func TestQueueIteratorFirst(t *testing.T) {
-	queue := New[string]()
+	queue := linkedlistqueue.New[string]()
 	it := queue.Iterator()
 	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -166,7 +167,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		queue := New[string]()
+		queue := linkedlistqueue.New[string]()
 		it := queue.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty queue")
@@ -175,7 +176,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		queue := New[string]()
+		queue := linkedlistqueue.New[string]()
 		queue.Enqueue("xx")
 		queue.Enqueue("yy")
 		it := queue.Iterator()
@@ -186,7 +187,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		queue := New[string]()
+		queue := linkedlistqueue.New[string]()
 		queue.Enqueue("aa")
 		queue.Enqueue("bb")
 		queue.Enqueue("cc")
@@ -211,7 +212,7 @@ func TestQueueIteratorNextTo(t *testing.T) {
 }
 
 func TestQueueSerialization(t *testing.T) {
-	queue := New[string]()
+	queue := linkedlistqueue.New[string]()
 	queue.Enqueue("a")
 	queue.Enqueue("b")
 	queue.Enqueue("c")
@@ -248,14 +249,14 @@ func TestQueueSerialization(t *testing.T) {
 }
 
 func TestQueueString(t *testing.T) {
-	c := New[int]()
+	c := linkedlistqueue.New[int]()
 	c.Enqueue(1)
 	if !strings.HasPrefix(c.String(), "LinkedListQueue") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkEnqueue(b *testing.B, queue *Queue[int], size int) {
+func benchmarkEnqueue(b *testing.B, queue *linkedlistqueue.Queue[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			queue.Enqueue(n)
@@ -263,7 +264,7 @@ func benchmarkEnqueue(b *testing.B, queue *Queue[int], size int) {
 	}
 }
 
-func benchmarkDequeue(b *testing.B, queue *Queue[int], size int) {
+func benchmarkDequeue(b *testing.B, queue *linkedlistqueue.Queue[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			queue.Dequeue()
@@ -274,7 +275,7 @@ func benchmarkDequeue(b *testing.B, queue *Queue[int], size int) {
 func BenchmarkArrayQueueDequeue100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -285,7 +286,7 @@ func BenchmarkArrayQueueDequeue100(b *testing.B) {
 func BenchmarkArrayQueueDequeue1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -296,7 +297,7 @@ func BenchmarkArrayQueueDequeue1000(b *testing.B) {
 func BenchmarkArrayQueueDequeue10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -307,7 +308,7 @@ func BenchmarkArrayQueueDequeue10000(b *testing.B) {
 func BenchmarkArrayQueueDequeue100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -318,7 +319,7 @@ func BenchmarkArrayQueueDequeue100000(b *testing.B) {
 func BenchmarkArrayQueueEnqueue100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	b.StartTimer()
 	benchmarkEnqueue(b, queue, size)
 }
@@ -326,7 +327,7 @@ func BenchmarkArrayQueueEnqueue100(b *testing.B) {
 func BenchmarkArrayQueueEnqueue1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -337,7 +338,7 @@ func BenchmarkArrayQueueEnqueue1000(b *testing.B) {
 func BenchmarkArrayQueueEnqueue10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}
@@ -348,7 +349,7 @@ func BenchmarkArrayQueueEnqueue10000(b *testing.B) {
 func BenchmarkArrayQueueEnqueue100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	queue := New[int]()
+	queue := linkedlistqueue.New[int]()
 	for n := 0; n < size; n++ {
 		queue.Enqueue(n)
 	}

--- a/queues/priorityqueue/priorityqueue_test.go
+++ b/queues/priorityqueue/priorityqueue_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package priorityqueue
+package priorityqueue_test
 
 import (
 	"cmp"
@@ -11,6 +11,8 @@ import (
 	"math/rand"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/queues/priorityqueue"
 )
 
 type Element struct {
@@ -28,7 +30,7 @@ func byPriority(a, b Element) int {
 }
 
 func TestBinaryQueueEnqueue(t *testing.T) {
-	queue := NewWith[Element](byPriority)
+	queue := priorityqueue.NewWith[Element](byPriority)
 
 	if actualValue := queue.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
@@ -75,7 +77,7 @@ func TestBinaryQueueEnqueue(t *testing.T) {
 }
 
 func TestBinaryQueueEnqueueBulk(t *testing.T) {
-	queue := New[int]()
+	queue := priorityqueue.New[int]()
 
 	queue.Enqueue(15)
 	queue.Enqueue(20)
@@ -106,7 +108,7 @@ func TestBinaryQueueEnqueueBulk(t *testing.T) {
 }
 
 func TestBinaryQueueDequeue(t *testing.T) {
-	queue := New[int]()
+	queue := priorityqueue.New[int]()
 
 	if actualValue := queue.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
@@ -135,7 +137,7 @@ func TestBinaryQueueDequeue(t *testing.T) {
 }
 
 func TestBinaryQueueRandom(t *testing.T) {
-	queue := New[int]()
+	queue := priorityqueue.New[int]()
 
 	rand.Seed(3)
 	for i := 0; i < 10000; i++ {
@@ -154,7 +156,7 @@ func TestBinaryQueueRandom(t *testing.T) {
 }
 
 func TestBinaryQueueIteratorOnEmpty(t *testing.T) {
-	queue := New[int]()
+	queue := priorityqueue.New[int]()
 	it := queue.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty queue")
@@ -162,7 +164,7 @@ func TestBinaryQueueIteratorOnEmpty(t *testing.T) {
 }
 
 func TestBinaryQueueIteratorNext(t *testing.T) {
-	queue := New[int]()
+	queue := priorityqueue.New[int]()
 	queue.Enqueue(3)
 	queue.Enqueue(2)
 	queue.Enqueue(1)
@@ -199,7 +201,7 @@ func TestBinaryQueueIteratorNext(t *testing.T) {
 }
 
 func TestBinaryQueueIteratorPrev(t *testing.T) {
-	queue := New[int]()
+	queue := priorityqueue.New[int]()
 	queue.Enqueue(3)
 	queue.Enqueue(2)
 	queue.Enqueue(1)
@@ -238,7 +240,7 @@ func TestBinaryQueueIteratorPrev(t *testing.T) {
 }
 
 func TestBinaryQueueIteratorBegin(t *testing.T) {
-	queue := New[int]()
+	queue := priorityqueue.New[int]()
 	it := queue.Iterator()
 	it.Begin()
 	queue.Enqueue(2)
@@ -254,7 +256,7 @@ func TestBinaryQueueIteratorBegin(t *testing.T) {
 }
 
 func TestBinaryQueueIteratorEnd(t *testing.T) {
-	queue := New[int]()
+	queue := priorityqueue.New[int]()
 	it := queue.Iterator()
 
 	if index := it.Index(); index != -1 {
@@ -281,7 +283,7 @@ func TestBinaryQueueIteratorEnd(t *testing.T) {
 }
 
 func TestBinaryQueueIteratorFirst(t *testing.T) {
-	queue := New[int]()
+	queue := priorityqueue.New[int]()
 	it := queue.Iterator()
 	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -298,7 +300,7 @@ func TestBinaryQueueIteratorFirst(t *testing.T) {
 }
 
 func TestBinaryQueueIteratorLast(t *testing.T) {
-	tree := New[int]()
+	tree := priorityqueue.New[int]()
 	it := tree.Iterator()
 	if actualValue, expectedValue := it.Last(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -322,7 +324,7 @@ func TestBinaryQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		tree := New[string]()
+		tree := priorityqueue.New[string]()
 		it := tree.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty list")
@@ -331,7 +333,7 @@ func TestBinaryQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		tree := New[string]()
+		tree := priorityqueue.New[string]()
 		tree.Enqueue("xx")
 		tree.Enqueue("yy")
 		it := tree.Iterator()
@@ -342,7 +344,7 @@ func TestBinaryQueueIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		tree := New[string]()
+		tree := priorityqueue.New[string]()
 		tree.Enqueue("aa")
 		tree.Enqueue("bb")
 		tree.Enqueue("cc")
@@ -374,7 +376,7 @@ func TestBinaryQueueIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		tree := New[string]()
+		tree := priorityqueue.New[string]()
 		it := tree.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -384,7 +386,7 @@ func TestBinaryQueueIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		tree := New[string]()
+		tree := priorityqueue.New[string]()
 		tree.Enqueue("xx")
 		tree.Enqueue("yy")
 		it := tree.Iterator()
@@ -396,7 +398,7 @@ func TestBinaryQueueIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		tree := New[string]()
+		tree := priorityqueue.New[string]()
 		tree.Enqueue("aa")
 		tree.Enqueue("bb")
 		tree.Enqueue("cc")
@@ -421,7 +423,7 @@ func TestBinaryQueueIteratorPrevTo(t *testing.T) {
 }
 
 func TestBinaryQueueSerialization(t *testing.T) {
-	queue := New[string]()
+	queue := priorityqueue.New[string]()
 
 	queue.Enqueue("c")
 	queue.Enqueue("b")
@@ -464,14 +466,14 @@ func TestBinaryQueueSerialization(t *testing.T) {
 }
 
 func TestBTreeString(t *testing.T) {
-	c := New[int]()
+	c := priorityqueue.New[int]()
 	c.Enqueue(1)
 	if !strings.HasPrefix(c.String(), "PriorityQueue") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkEnqueue(b *testing.B, queue *Queue[Element], size int) {
+func benchmarkEnqueue(b *testing.B, queue *priorityqueue.Queue[Element], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			queue.Enqueue(Element{})
@@ -479,7 +481,7 @@ func benchmarkEnqueue(b *testing.B, queue *Queue[Element], size int) {
 	}
 }
 
-func benchmarkDequeue(b *testing.B, queue *Queue[Element], size int) {
+func benchmarkDequeue(b *testing.B, queue *priorityqueue.Queue[Element], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			queue.Dequeue()
@@ -490,7 +492,7 @@ func benchmarkDequeue(b *testing.B, queue *Queue[Element], size int) {
 func BenchmarkBinaryQueueDequeue100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	queue := NewWith[Element](byPriority)
+	queue := priorityqueue.NewWith[Element](byPriority)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(Element{})
 	}
@@ -501,7 +503,7 @@ func BenchmarkBinaryQueueDequeue100(b *testing.B) {
 func BenchmarkBinaryQueueDequeue1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	queue := NewWith[Element](byPriority)
+	queue := priorityqueue.NewWith[Element](byPriority)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(Element{})
 	}
@@ -512,7 +514,7 @@ func BenchmarkBinaryQueueDequeue1000(b *testing.B) {
 func BenchmarkBinaryQueueDequeue10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	queue := NewWith[Element](byPriority)
+	queue := priorityqueue.NewWith[Element](byPriority)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(Element{})
 	}
@@ -523,7 +525,7 @@ func BenchmarkBinaryQueueDequeue10000(b *testing.B) {
 func BenchmarkBinaryQueueDequeue100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	queue := NewWith[Element](byPriority)
+	queue := priorityqueue.NewWith[Element](byPriority)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(Element{})
 	}
@@ -534,7 +536,7 @@ func BenchmarkBinaryQueueDequeue100000(b *testing.B) {
 func BenchmarkBinaryQueueEnqueue100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	queue := NewWith(byPriority)
+	queue := priorityqueue.NewWith(byPriority)
 	b.StartTimer()
 	benchmarkEnqueue(b, queue, size)
 }
@@ -542,7 +544,7 @@ func BenchmarkBinaryQueueEnqueue100(b *testing.B) {
 func BenchmarkBinaryQueueEnqueue1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	queue := NewWith[Element](byPriority)
+	queue := priorityqueue.NewWith[Element](byPriority)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(Element{})
 	}
@@ -553,7 +555,7 @@ func BenchmarkBinaryQueueEnqueue1000(b *testing.B) {
 func BenchmarkBinaryQueueEnqueue10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	queue := NewWith[Element](byPriority)
+	queue := priorityqueue.NewWith[Element](byPriority)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(Element{})
 	}
@@ -564,7 +566,7 @@ func BenchmarkBinaryQueueEnqueue10000(b *testing.B) {
 func BenchmarkBinaryQueueEnqueue100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	queue := NewWith[Element](byPriority)
+	queue := priorityqueue.NewWith[Element](byPriority)
 	for n := 0; n < size; n++ {
 		queue.Enqueue(Element{})
 	}

--- a/sets/hashset/hashset_test.go
+++ b/sets/hashset/hashset_test.go
@@ -2,16 +2,18 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package hashset
+package hashset_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/sets/hashset"
 )
 
 func TestSetNew(t *testing.T) {
-	set := New(2, 1)
+	set := hashset.New(2, 1)
 
 	if actualValue := set.Size(); actualValue != 2 {
 		t.Errorf("Got %v expected %v", actualValue, 2)
@@ -28,7 +30,7 @@ func TestSetNew(t *testing.T) {
 }
 
 func TestSetAdd(t *testing.T) {
-	set := New[int]()
+	set := hashset.New[int]()
 	set.Add()
 	set.Add(1)
 	set.Add(2)
@@ -43,7 +45,7 @@ func TestSetAdd(t *testing.T) {
 }
 
 func TestSetContains(t *testing.T) {
-	set := New[int]()
+	set := hashset.New[int]()
 	set.Add(3, 1, 2)
 	set.Add(2, 3)
 	set.Add()
@@ -62,7 +64,7 @@ func TestSetContains(t *testing.T) {
 }
 
 func TestSetRemove(t *testing.T) {
-	set := New[int]()
+	set := hashset.New[int]()
 	set.Add(3, 1, 2)
 	set.Remove()
 	if actualValue := set.Size(); actualValue != 3 {
@@ -82,7 +84,7 @@ func TestSetRemove(t *testing.T) {
 }
 
 func TestSetSerialization(t *testing.T) {
-	set := New[string]()
+	set := hashset.New[string]()
 	set.Add("a", "b", "c")
 
 	var err error
@@ -119,7 +121,7 @@ func TestSetSerialization(t *testing.T) {
 }
 
 func TestSetString(t *testing.T) {
-	c := New[int]()
+	c := hashset.New[int]()
 	c.Add(1)
 	if !strings.HasPrefix(c.String(), "HashSet") {
 		t.Errorf("String should start with container name")
@@ -127,8 +129,8 @@ func TestSetString(t *testing.T) {
 }
 
 func TestSetIntersection(t *testing.T) {
-	set := New[string]()
-	another := New[string]()
+	set := hashset.New[string]()
+	another := hashset.New[string]()
 
 	intersection := set.Intersection(another)
 	if actualValue, expectedValue := intersection.Size(), 0; actualValue != expectedValue {
@@ -149,8 +151,8 @@ func TestSetIntersection(t *testing.T) {
 }
 
 func TestSetUnion(t *testing.T) {
-	set := New[string]()
-	another := New[string]()
+	set := hashset.New[string]()
+	another := hashset.New[string]()
 
 	union := set.Union(another)
 	if actualValue, expectedValue := union.Size(), 0; actualValue != expectedValue {
@@ -171,8 +173,8 @@ func TestSetUnion(t *testing.T) {
 }
 
 func TestSetDifference(t *testing.T) {
-	set := New[string]()
-	another := New[string]()
+	set := hashset.New[string]()
+	another := hashset.New[string]()
 
 	difference := set.Difference(another)
 	if actualValue, expectedValue := difference.Size(), 0; actualValue != expectedValue {
@@ -192,7 +194,7 @@ func TestSetDifference(t *testing.T) {
 	}
 }
 
-func benchmarkContains(b *testing.B, set *Set[int], size int) {
+func benchmarkContains(b *testing.B, set *hashset.Set[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			set.Contains(n)
@@ -200,7 +202,7 @@ func benchmarkContains(b *testing.B, set *Set[int], size int) {
 	}
 }
 
-func benchmarkAdd(b *testing.B, set *Set[int], size int) {
+func benchmarkAdd(b *testing.B, set *hashset.Set[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			set.Add(n)
@@ -208,7 +210,7 @@ func benchmarkAdd(b *testing.B, set *Set[int], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, set *Set[int], size int) {
+func benchmarkRemove(b *testing.B, set *hashset.Set[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			set.Remove(n)
@@ -219,7 +221,7 @@ func benchmarkRemove(b *testing.B, set *Set[int], size int) {
 func BenchmarkHashSetContains100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -230,7 +232,7 @@ func BenchmarkHashSetContains100(b *testing.B) {
 func BenchmarkHashSetContains1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -241,7 +243,7 @@ func BenchmarkHashSetContains1000(b *testing.B) {
 func BenchmarkHashSetContains10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -252,7 +254,7 @@ func BenchmarkHashSetContains10000(b *testing.B) {
 func BenchmarkHashSetContains100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -263,7 +265,7 @@ func BenchmarkHashSetContains100000(b *testing.B) {
 func BenchmarkHashSetAdd100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	set := New[int]()
+	set := hashset.New[int]()
 	b.StartTimer()
 	benchmarkAdd(b, set, size)
 }
@@ -271,7 +273,7 @@ func BenchmarkHashSetAdd100(b *testing.B) {
 func BenchmarkHashSetAdd1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -282,7 +284,7 @@ func BenchmarkHashSetAdd1000(b *testing.B) {
 func BenchmarkHashSetAdd10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -293,7 +295,7 @@ func BenchmarkHashSetAdd10000(b *testing.B) {
 func BenchmarkHashSetAdd100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -304,7 +306,7 @@ func BenchmarkHashSetAdd100000(b *testing.B) {
 func BenchmarkHashSetRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -315,7 +317,7 @@ func BenchmarkHashSetRemove100(b *testing.B) {
 func BenchmarkHashSetRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -326,7 +328,7 @@ func BenchmarkHashSetRemove1000(b *testing.B) {
 func BenchmarkHashSetRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -337,7 +339,7 @@ func BenchmarkHashSetRemove10000(b *testing.B) {
 func BenchmarkHashSetRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	set := New[int]()
+	set := hashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}

--- a/sets/linkedhashset/linkedhashset_test.go
+++ b/sets/linkedhashset/linkedhashset_test.go
@@ -2,17 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package linkedhashset
+package linkedhashset_test
 
 import (
 	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/sets/linkedhashset"
 )
 
 func TestSetNew(t *testing.T) {
-	set := New(2, 1)
+	set := linkedhashset.New(2, 1)
 
 	if actualValue := set.Size(); actualValue != 2 {
 		t.Errorf("Got %v expected %v", actualValue, 2)
@@ -29,7 +31,7 @@ func TestSetNew(t *testing.T) {
 }
 
 func TestSetAdd(t *testing.T) {
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	set.Add()
 	set.Add(1)
 	set.Add(2)
@@ -44,7 +46,7 @@ func TestSetAdd(t *testing.T) {
 }
 
 func TestSetContains(t *testing.T) {
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	set.Add(3, 1, 2)
 	set.Add(2, 3)
 	set.Add()
@@ -63,7 +65,7 @@ func TestSetContains(t *testing.T) {
 }
 
 func TestSetRemove(t *testing.T) {
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	set.Add(3, 1, 2)
 	set.Remove()
 	if actualValue := set.Size(); actualValue != 3 {
@@ -83,7 +85,7 @@ func TestSetRemove(t *testing.T) {
 }
 
 func TestSetEach(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("c", "a", "b")
 	set.Each(func(index int, value string) {
 		switch index {
@@ -106,7 +108,7 @@ func TestSetEach(t *testing.T) {
 }
 
 func TestSetMap(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("c", "a", "b")
 	mappedSet := set.Map(func(index int, value string) string {
 		return "mapped: " + value
@@ -123,7 +125,7 @@ func TestSetMap(t *testing.T) {
 }
 
 func TestSetSelect(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("c", "a", "b")
 	selectedSet := set.Select(func(index int, value string) bool {
 		return value >= "a" && value <= "b"
@@ -141,7 +143,7 @@ func TestSetSelect(t *testing.T) {
 }
 
 func TestSetAny(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("c", "a", "b")
 	any := set.Any(func(index int, value string) bool {
 		return value == "c"
@@ -158,7 +160,7 @@ func TestSetAny(t *testing.T) {
 }
 
 func TestSetAll(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("c", "a", "b")
 	all := set.All(func(index int, value string) bool {
 		return value >= "a" && value <= "c"
@@ -175,7 +177,7 @@ func TestSetAll(t *testing.T) {
 }
 
 func TestSetFind(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("c", "a", "b")
 	foundIndex, foundValue := set.Find(func(index int, value string) bool {
 		return value == "c"
@@ -192,12 +194,12 @@ func TestSetFind(t *testing.T) {
 }
 
 func TestSetChaining(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("c", "a", "b")
 }
 
 func TestSetIteratorPrevOnEmpty(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	it := set.Iterator()
 	for it.Prev() {
 		t.Errorf("Shouldn't iterate on empty set")
@@ -205,7 +207,7 @@ func TestSetIteratorPrevOnEmpty(t *testing.T) {
 }
 
 func TestSetIteratorNext(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("c", "a", "b")
 	it := set.Iterator()
 	count := 0
@@ -239,7 +241,7 @@ func TestSetIteratorNext(t *testing.T) {
 }
 
 func TestSetIteratorPrev(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("c", "a", "b")
 	it := set.Iterator()
 	for it.Prev() {
@@ -275,7 +277,7 @@ func TestSetIteratorPrev(t *testing.T) {
 }
 
 func TestSetIteratorBegin(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	it := set.Iterator()
 	it.Begin()
 	set.Add("a", "b", "c")
@@ -289,7 +291,7 @@ func TestSetIteratorBegin(t *testing.T) {
 }
 
 func TestSetIteratorEnd(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	it := set.Iterator()
 
 	if index := it.Index(); index != -1 {
@@ -314,7 +316,7 @@ func TestSetIteratorEnd(t *testing.T) {
 }
 
 func TestSetIteratorFirst(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("a", "b", "c")
 	it := set.Iterator()
 	if actualValue, expectedValue := it.First(), true; actualValue != expectedValue {
@@ -326,7 +328,7 @@ func TestSetIteratorFirst(t *testing.T) {
 }
 
 func TestSetIteratorLast(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("a", "b", "c")
 	it := set.Iterator()
 	if actualValue, expectedValue := it.Last(), true; actualValue != expectedValue {
@@ -345,7 +347,7 @@ func TestSetIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		set := New[string]()
+		set := linkedhashset.New[string]()
 		it := set.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty set")
@@ -354,7 +356,7 @@ func TestSetIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		set := New[string]()
+		set := linkedhashset.New[string]()
 		set.Add("xx", "yy")
 		it := set.Iterator()
 		for it.NextTo(seek) {
@@ -364,7 +366,7 @@ func TestSetIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		set := New[string]()
+		set := linkedhashset.New[string]()
 		set.Add("aa", "bb", "cc")
 		it := set.Iterator()
 		it.Begin()
@@ -394,7 +396,7 @@ func TestSetIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		set := New[string]()
+		set := linkedhashset.New[string]()
 		it := set.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -404,7 +406,7 @@ func TestSetIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		set := New[string]()
+		set := linkedhashset.New[string]()
 		set.Add("xx", "yy")
 		it := set.Iterator()
 		it.End()
@@ -415,7 +417,7 @@ func TestSetIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		set := New[string]()
+		set := linkedhashset.New[string]()
 		set.Add("aa", "bb", "cc")
 		it := set.Iterator()
 		it.End()
@@ -438,7 +440,7 @@ func TestSetIteratorPrevTo(t *testing.T) {
 }
 
 func TestSetSerialization(t *testing.T) {
-	set := New[string]()
+	set := linkedhashset.New[string]()
 	set.Add("a", "b", "c")
 
 	var err error
@@ -475,7 +477,7 @@ func TestSetSerialization(t *testing.T) {
 }
 
 func TestSetString(t *testing.T) {
-	c := New[int]()
+	c := linkedhashset.New[int]()
 	c.Add(1)
 	if !strings.HasPrefix(c.String(), "LinkedHashSet") {
 		t.Errorf("String should start with container name")
@@ -483,8 +485,8 @@ func TestSetString(t *testing.T) {
 }
 
 func TestSetIntersection(t *testing.T) {
-	set := New[string]()
-	another := New[string]()
+	set := linkedhashset.New[string]()
+	another := linkedhashset.New[string]()
 
 	intersection := set.Intersection(another)
 	if actualValue, expectedValue := intersection.Size(), 0; actualValue != expectedValue {
@@ -505,8 +507,8 @@ func TestSetIntersection(t *testing.T) {
 }
 
 func TestSetUnion(t *testing.T) {
-	set := New[string]()
-	another := New[string]()
+	set := linkedhashset.New[string]()
+	another := linkedhashset.New[string]()
 
 	union := set.Union(another)
 	if actualValue, expectedValue := union.Size(), 0; actualValue != expectedValue {
@@ -527,8 +529,8 @@ func TestSetUnion(t *testing.T) {
 }
 
 func TestSetDifference(t *testing.T) {
-	set := New[string]()
-	another := New[string]()
+	set := linkedhashset.New[string]()
+	another := linkedhashset.New[string]()
 
 	difference := set.Difference(another)
 	if actualValue, expectedValue := difference.Size(), 0; actualValue != expectedValue {
@@ -548,7 +550,7 @@ func TestSetDifference(t *testing.T) {
 	}
 }
 
-func benchmarkContains(b *testing.B, set *Set[int], size int) {
+func benchmarkContains(b *testing.B, set *linkedhashset.Set[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			set.Contains(n)
@@ -556,7 +558,7 @@ func benchmarkContains(b *testing.B, set *Set[int], size int) {
 	}
 }
 
-func benchmarkAdd(b *testing.B, set *Set[int], size int) {
+func benchmarkAdd(b *testing.B, set *linkedhashset.Set[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			set.Add(n)
@@ -564,7 +566,7 @@ func benchmarkAdd(b *testing.B, set *Set[int], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, set *Set[int], size int) {
+func benchmarkRemove(b *testing.B, set *linkedhashset.Set[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			set.Remove(n)
@@ -575,7 +577,7 @@ func benchmarkRemove(b *testing.B, set *Set[int], size int) {
 func BenchmarkHashSetContains100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -586,7 +588,7 @@ func BenchmarkHashSetContains100(b *testing.B) {
 func BenchmarkHashSetContains1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -597,7 +599,7 @@ func BenchmarkHashSetContains1000(b *testing.B) {
 func BenchmarkHashSetContains10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -608,7 +610,7 @@ func BenchmarkHashSetContains10000(b *testing.B) {
 func BenchmarkHashSetContains100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -619,7 +621,7 @@ func BenchmarkHashSetContains100000(b *testing.B) {
 func BenchmarkHashSetAdd100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	b.StartTimer()
 	benchmarkAdd(b, set, size)
 }
@@ -627,7 +629,7 @@ func BenchmarkHashSetAdd100(b *testing.B) {
 func BenchmarkHashSetAdd1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -638,7 +640,7 @@ func BenchmarkHashSetAdd1000(b *testing.B) {
 func BenchmarkHashSetAdd10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -649,7 +651,7 @@ func BenchmarkHashSetAdd10000(b *testing.B) {
 func BenchmarkHashSetAdd100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -660,7 +662,7 @@ func BenchmarkHashSetAdd100000(b *testing.B) {
 func BenchmarkHashSetRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -671,7 +673,7 @@ func BenchmarkHashSetRemove100(b *testing.B) {
 func BenchmarkHashSetRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -682,7 +684,7 @@ func BenchmarkHashSetRemove1000(b *testing.B) {
 func BenchmarkHashSetRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -693,7 +695,7 @@ func BenchmarkHashSetRemove10000(b *testing.B) {
 func BenchmarkHashSetRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	set := New[int]()
+	set := linkedhashset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}

--- a/sets/treeset/treeset_test.go
+++ b/sets/treeset/treeset_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package treeset
+package treeset_test
 
 import (
 	"encoding/json"
@@ -10,11 +10,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/sets/treeset"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestSetNew(t *testing.T) {
-	set := New[int](2, 1)
+	set := treeset.New[int](2, 1)
 	if actualValue := set.Size(); actualValue != 2 {
 		t.Errorf("Got %v expected %v", actualValue, 2)
 	}
@@ -28,7 +29,7 @@ func TestSetNew(t *testing.T) {
 }
 
 func TestSetAdd(t *testing.T) {
-	set := New[int]()
+	set := treeset.New[int]()
 	set.Add()
 	set.Add(1)
 	set.Add(2)
@@ -44,7 +45,7 @@ func TestSetAdd(t *testing.T) {
 }
 
 func TestSetContains(t *testing.T) {
-	set := New[int]()
+	set := treeset.New[int]()
 	set.Add(3, 1, 2)
 	if actualValue := set.Contains(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
@@ -61,7 +62,7 @@ func TestSetContains(t *testing.T) {
 }
 
 func TestSetRemove(t *testing.T) {
-	set := New[int]()
+	set := treeset.New[int]()
 	set.Add(3, 1, 2)
 	set.Remove()
 	if actualValue := set.Size(); actualValue != 3 {
@@ -81,7 +82,7 @@ func TestSetRemove(t *testing.T) {
 }
 
 func TestSetEach(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("c", "a", "b")
 	set.Each(func(index int, value string) {
 		switch index {
@@ -104,7 +105,7 @@ func TestSetEach(t *testing.T) {
 }
 
 func TestSetMap(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("c", "a", "b")
 	mappedSet := set.Map(func(index int, value string) string {
 		return "mapped: " + value
@@ -121,7 +122,7 @@ func TestSetMap(t *testing.T) {
 }
 
 func TestSetSelect(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("c", "a", "b")
 	selectedSet := set.Select(func(index int, value string) bool {
 		return value >= "a" && value <= "b"
@@ -139,7 +140,7 @@ func TestSetSelect(t *testing.T) {
 }
 
 func TestSetAny(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("c", "a", "b")
 	any := set.Any(func(index int, value string) bool {
 		return value == "c"
@@ -156,7 +157,7 @@ func TestSetAny(t *testing.T) {
 }
 
 func TestSetAll(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("c", "a", "b")
 	all := set.All(func(index int, value string) bool {
 		return value >= "a" && value <= "c"
@@ -173,7 +174,7 @@ func TestSetAll(t *testing.T) {
 }
 
 func TestSetFind(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("c", "a", "b")
 	foundIndex, foundValue := set.Find(func(index int, value string) bool {
 		return value == "c"
@@ -190,12 +191,12 @@ func TestSetFind(t *testing.T) {
 }
 
 func TestSetChaining(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("c", "a", "b")
 }
 
 func TestSetIteratorNextOnEmpty(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	it := set.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty set")
@@ -203,7 +204,7 @@ func TestSetIteratorNextOnEmpty(t *testing.T) {
 }
 
 func TestSetIteratorPrevOnEmpty(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	it := set.Iterator()
 	for it.Prev() {
 		t.Errorf("Shouldn't iterate on empty set")
@@ -211,7 +212,7 @@ func TestSetIteratorPrevOnEmpty(t *testing.T) {
 }
 
 func TestSetIteratorNext(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("c", "a", "b")
 	it := set.Iterator()
 	count := 0
@@ -245,7 +246,7 @@ func TestSetIteratorNext(t *testing.T) {
 }
 
 func TestSetIteratorPrev(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("c", "a", "b")
 	it := set.Iterator()
 	for it.Prev() {
@@ -281,7 +282,7 @@ func TestSetIteratorPrev(t *testing.T) {
 }
 
 func TestSetIteratorBegin(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	it := set.Iterator()
 	it.Begin()
 	set.Add("a", "b", "c")
@@ -295,7 +296,7 @@ func TestSetIteratorBegin(t *testing.T) {
 }
 
 func TestSetIteratorEnd(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	it := set.Iterator()
 
 	if index := it.Index(); index != -1 {
@@ -320,7 +321,7 @@ func TestSetIteratorEnd(t *testing.T) {
 }
 
 func TestSetIteratorFirst(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("a", "b", "c")
 	it := set.Iterator()
 	if actualValue, expectedValue := it.First(), true; actualValue != expectedValue {
@@ -332,7 +333,7 @@ func TestSetIteratorFirst(t *testing.T) {
 }
 
 func TestSetIteratorLast(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("a", "b", "c")
 	it := set.Iterator()
 	if actualValue, expectedValue := it.Last(), true; actualValue != expectedValue {
@@ -351,7 +352,7 @@ func TestSetIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		set := New[string]()
+		set := treeset.New[string]()
 		it := set.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty set")
@@ -360,7 +361,7 @@ func TestSetIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		set := New[string]()
+		set := treeset.New[string]()
 		set.Add("xx", "yy")
 		it := set.Iterator()
 		for it.NextTo(seek) {
@@ -370,7 +371,7 @@ func TestSetIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		set := New[string]()
+		set := treeset.New[string]()
 		set.Add("aa", "bb", "cc")
 		it := set.Iterator()
 		it.Begin()
@@ -400,7 +401,7 @@ func TestSetIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		set := New[string]()
+		set := treeset.New[string]()
 		it := set.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -410,7 +411,7 @@ func TestSetIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		set := New[string]()
+		set := treeset.New[string]()
 		set.Add("xx", "yy")
 		it := set.Iterator()
 		it.End()
@@ -421,7 +422,7 @@ func TestSetIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		set := New[string]()
+		set := treeset.New[string]()
 		set.Add("aa", "bb", "cc")
 		it := set.Iterator()
 		it.End()
@@ -444,7 +445,7 @@ func TestSetIteratorPrevTo(t *testing.T) {
 }
 
 func TestSetSerialization(t *testing.T) {
-	set := New[string]()
+	set := treeset.New[string]()
 	set.Add("a", "b", "c")
 
 	var err error
@@ -480,7 +481,7 @@ func TestSetSerialization(t *testing.T) {
 }
 
 func TestSetString(t *testing.T) {
-	c := New[int]()
+	c := treeset.New[int]()
 	c.Add(1)
 	if !strings.HasPrefix(c.String(), "TreeSet") {
 		t.Errorf("String should start with container name")
@@ -488,8 +489,8 @@ func TestSetString(t *testing.T) {
 }
 
 func TestSetIntersection(t *testing.T) {
-	set := New[string]()
-	another := New[string]()
+	set := treeset.New[string]()
+	another := treeset.New[string]()
 
 	intersection := set.Intersection(another)
 	if actualValue, expectedValue := intersection.Size(), 0; actualValue != expectedValue {
@@ -510,8 +511,8 @@ func TestSetIntersection(t *testing.T) {
 }
 
 func TestSetUnion(t *testing.T) {
-	set := New[string]()
-	another := New[string]()
+	set := treeset.New[string]()
+	another := treeset.New[string]()
 
 	union := set.Union(another)
 	if actualValue, expectedValue := union.Size(), 0; actualValue != expectedValue {
@@ -532,8 +533,8 @@ func TestSetUnion(t *testing.T) {
 }
 
 func TestSetDifference(t *testing.T) {
-	set := New[string]()
-	another := New[string]()
+	set := treeset.New[string]()
+	another := treeset.New[string]()
 
 	difference := set.Difference(another)
 	if actualValue, expectedValue := difference.Size(), 0; actualValue != expectedValue {
@@ -553,7 +554,7 @@ func TestSetDifference(t *testing.T) {
 	}
 }
 
-func benchmarkContains(b *testing.B, set *Set[int], size int) {
+func benchmarkContains(b *testing.B, set *treeset.Set[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			set.Contains(n)
@@ -561,7 +562,7 @@ func benchmarkContains(b *testing.B, set *Set[int], size int) {
 	}
 }
 
-func benchmarkAdd(b *testing.B, set *Set[int], size int) {
+func benchmarkAdd(b *testing.B, set *treeset.Set[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			set.Add(n)
@@ -569,7 +570,7 @@ func benchmarkAdd(b *testing.B, set *Set[int], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, set *Set[int], size int) {
+func benchmarkRemove(b *testing.B, set *treeset.Set[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			set.Remove(n)
@@ -580,7 +581,7 @@ func benchmarkRemove(b *testing.B, set *Set[int], size int) {
 func BenchmarkTreeSetContains100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -591,7 +592,7 @@ func BenchmarkTreeSetContains100(b *testing.B) {
 func BenchmarkTreeSetContains1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -602,7 +603,7 @@ func BenchmarkTreeSetContains1000(b *testing.B) {
 func BenchmarkTreeSetContains10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -613,7 +614,7 @@ func BenchmarkTreeSetContains10000(b *testing.B) {
 func BenchmarkTreeSetContains100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -624,7 +625,7 @@ func BenchmarkTreeSetContains100000(b *testing.B) {
 func BenchmarkTreeSetAdd100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	set := New[int]()
+	set := treeset.New[int]()
 	b.StartTimer()
 	benchmarkAdd(b, set, size)
 }
@@ -632,7 +633,7 @@ func BenchmarkTreeSetAdd100(b *testing.B) {
 func BenchmarkTreeSetAdd1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -643,7 +644,7 @@ func BenchmarkTreeSetAdd1000(b *testing.B) {
 func BenchmarkTreeSetAdd10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -654,7 +655,7 @@ func BenchmarkTreeSetAdd10000(b *testing.B) {
 func BenchmarkTreeSetAdd100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -665,7 +666,7 @@ func BenchmarkTreeSetAdd100000(b *testing.B) {
 func BenchmarkTreeSetRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -676,7 +677,7 @@ func BenchmarkTreeSetRemove100(b *testing.B) {
 func BenchmarkTreeSetRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -687,7 +688,7 @@ func BenchmarkTreeSetRemove1000(b *testing.B) {
 func BenchmarkTreeSetRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}
@@ -698,7 +699,7 @@ func BenchmarkTreeSetRemove10000(b *testing.B) {
 func BenchmarkTreeSetRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	set := New[int]()
+	set := treeset.New[int]()
 	for n := 0; n < size; n++ {
 		set.Add(n)
 	}

--- a/stacks/arraystack/arraystack_test.go
+++ b/stacks/arraystack/arraystack_test.go
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package arraystack
+package arraystack_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/stacks/arraystack"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestStackPush(t *testing.T) {
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	if actualValue := stack.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
 	}
@@ -36,7 +37,7 @@ func TestStackPush(t *testing.T) {
 }
 
 func TestStackPeek(t *testing.T) {
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	if actualValue, ok := stack.Peek(); actualValue != 0 || ok {
 		t.Errorf("Got %v expected %v", actualValue, nil)
 	}
@@ -49,7 +50,7 @@ func TestStackPeek(t *testing.T) {
 }
 
 func TestStackPop(t *testing.T) {
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	stack.Push(1)
 	stack.Push(2)
 	stack.Push(3)
@@ -75,7 +76,7 @@ func TestStackPop(t *testing.T) {
 }
 
 func TestStackIteratorOnEmpty(t *testing.T) {
-	stack := New[string]()
+	stack := arraystack.New[string]()
 	it := stack.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty stack")
@@ -83,7 +84,7 @@ func TestStackIteratorOnEmpty(t *testing.T) {
 }
 
 func TestStackIteratorNext(t *testing.T) {
-	stack := New[string]()
+	stack := arraystack.New[string]()
 	stack.Push("a")
 	stack.Push("b")
 	stack.Push("c")
@@ -126,7 +127,7 @@ func TestStackIteratorNext(t *testing.T) {
 }
 
 func TestStackIteratorPrev(t *testing.T) {
-	stack := New[string]()
+	stack := arraystack.New[string]()
 	stack.Push("a")
 	stack.Push("b")
 	stack.Push("c")
@@ -165,7 +166,7 @@ func TestStackIteratorPrev(t *testing.T) {
 }
 
 func TestStackIteratorBegin(t *testing.T) {
-	stack := New[string]()
+	stack := arraystack.New[string]()
 	it := stack.Iterator()
 	it.Begin()
 	stack.Push("a")
@@ -181,7 +182,7 @@ func TestStackIteratorBegin(t *testing.T) {
 }
 
 func TestStackIteratorEnd(t *testing.T) {
-	stack := New[string]()
+	stack := arraystack.New[string]()
 	it := stack.Iterator()
 
 	if index := it.Index(); index != -1 {
@@ -208,7 +209,7 @@ func TestStackIteratorEnd(t *testing.T) {
 }
 
 func TestStackIteratorFirst(t *testing.T) {
-	stack := New[string]()
+	stack := arraystack.New[string]()
 	it := stack.Iterator()
 	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -225,7 +226,7 @@ func TestStackIteratorFirst(t *testing.T) {
 }
 
 func TestStackIteratorLast(t *testing.T) {
-	stack := New[string]()
+	stack := arraystack.New[string]()
 	it := stack.Iterator()
 	if actualValue, expectedValue := it.Last(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -249,7 +250,7 @@ func TestStackIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		stack := New[string]()
+		stack := arraystack.New[string]()
 		it := stack.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty stack")
@@ -258,7 +259,7 @@ func TestStackIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		stack := New[string]()
+		stack := arraystack.New[string]()
 		stack.Push("xx")
 		stack.Push("yy")
 		it := stack.Iterator()
@@ -269,7 +270,7 @@ func TestStackIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		stack := New[string]()
+		stack := arraystack.New[string]()
 		stack.Push("aa")
 		stack.Push("bb")
 		stack.Push("cc")
@@ -301,7 +302,7 @@ func TestStackIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		stack := New[string]()
+		stack := arraystack.New[string]()
 		it := stack.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -311,7 +312,7 @@ func TestStackIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		stack := New[string]()
+		stack := arraystack.New[string]()
 		stack.Push("xx")
 		stack.Push("yy")
 		it := stack.Iterator()
@@ -323,7 +324,7 @@ func TestStackIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		stack := New[string]()
+		stack := arraystack.New[string]()
 		stack.Push("aa")
 		stack.Push("bb")
 		stack.Push("cc")
@@ -348,7 +349,7 @@ func TestStackIteratorPrevTo(t *testing.T) {
 }
 
 func TestStackSerialization(t *testing.T) {
-	stack := New[string]()
+	stack := arraystack.New[string]()
 	stack.Push("a")
 	stack.Push("b")
 	stack.Push("c")
@@ -385,14 +386,14 @@ func TestStackSerialization(t *testing.T) {
 }
 
 func TestStackString(t *testing.T) {
-	c := New[int]()
+	c := arraystack.New[int]()
 	c.Push(1)
 	if !strings.HasPrefix(c.String(), "ArrayStack") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkPush(b *testing.B, stack *Stack[int], size int) {
+func benchmarkPush(b *testing.B, stack *arraystack.Stack[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			stack.Push(n)
@@ -400,7 +401,7 @@ func benchmarkPush(b *testing.B, stack *Stack[int], size int) {
 	}
 }
 
-func benchmarkPop(b *testing.B, stack *Stack[int], size int) {
+func benchmarkPop(b *testing.B, stack *arraystack.Stack[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			stack.Pop()
@@ -411,7 +412,7 @@ func benchmarkPop(b *testing.B, stack *Stack[int], size int) {
 func BenchmarkArrayStackPop100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -422,7 +423,7 @@ func BenchmarkArrayStackPop100(b *testing.B) {
 func BenchmarkArrayStackPop1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -433,7 +434,7 @@ func BenchmarkArrayStackPop1000(b *testing.B) {
 func BenchmarkArrayStackPop10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -444,7 +445,7 @@ func BenchmarkArrayStackPop10000(b *testing.B) {
 func BenchmarkArrayStackPop100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -455,7 +456,7 @@ func BenchmarkArrayStackPop100000(b *testing.B) {
 func BenchmarkArrayStackPush100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	b.StartTimer()
 	benchmarkPush(b, stack, size)
 }
@@ -463,7 +464,7 @@ func BenchmarkArrayStackPush100(b *testing.B) {
 func BenchmarkArrayStackPush1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -474,7 +475,7 @@ func BenchmarkArrayStackPush1000(b *testing.B) {
 func BenchmarkArrayStackPush10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -485,7 +486,7 @@ func BenchmarkArrayStackPush10000(b *testing.B) {
 func BenchmarkArrayStackPush100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	stack := New[int]()
+	stack := arraystack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}

--- a/stacks/linkedliststack/linkedliststack_test.go
+++ b/stacks/linkedliststack/linkedliststack_test.go
@@ -2,18 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package linkedliststack
+package linkedliststack_test
 
 import (
 	"encoding/json"
 	"strings"
 	"testing"
 
+	"github.com/emirpasic/gods/v2/stacks/linkedliststack"
 	"github.com/emirpasic/gods/v2/testutils"
 )
 
 func TestStackPush(t *testing.T) {
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	if actualValue := stack.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
 	}
@@ -36,7 +37,7 @@ func TestStackPush(t *testing.T) {
 }
 
 func TestStackPeek(t *testing.T) {
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	if actualValue, ok := stack.Peek(); actualValue != 0 || ok {
 		t.Errorf("Got %v expected %v", actualValue, nil)
 	}
@@ -49,7 +50,7 @@ func TestStackPeek(t *testing.T) {
 }
 
 func TestStackPop(t *testing.T) {
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	stack.Push(1)
 	stack.Push(2)
 	stack.Push(3)
@@ -75,7 +76,7 @@ func TestStackPop(t *testing.T) {
 }
 
 func TestStackIterator(t *testing.T) {
-	stack := New[string]()
+	stack := linkedliststack.New[string]()
 	stack.Push("a")
 	stack.Push("b")
 	stack.Push("c")
@@ -119,7 +120,7 @@ func TestStackIterator(t *testing.T) {
 }
 
 func TestStackIteratorBegin(t *testing.T) {
-	stack := New[string]()
+	stack := linkedliststack.New[string]()
 	it := stack.Iterator()
 	it.Begin()
 	stack.Push("a")
@@ -135,7 +136,7 @@ func TestStackIteratorBegin(t *testing.T) {
 }
 
 func TestStackIteratorFirst(t *testing.T) {
-	stack := New[string]()
+	stack := linkedliststack.New[string]()
 	it := stack.Iterator()
 	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -159,7 +160,7 @@ func TestStackIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		stack := New[string]()
+		stack := linkedliststack.New[string]()
 		it := stack.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty stack")
@@ -168,7 +169,7 @@ func TestStackIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		stack := New[string]()
+		stack := linkedliststack.New[string]()
 		stack.Push("xx")
 		stack.Push("yy")
 		it := stack.Iterator()
@@ -179,7 +180,7 @@ func TestStackIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		stack := New[string]()
+		stack := linkedliststack.New[string]()
 		stack.Push("aa")
 		stack.Push("bb")
 		stack.Push("cc")
@@ -204,7 +205,7 @@ func TestStackIteratorNextTo(t *testing.T) {
 }
 
 func TestStackSerialization(t *testing.T) {
-	stack := New[string]()
+	stack := linkedliststack.New[string]()
 	stack.Push("a")
 	stack.Push("b")
 	stack.Push("c")
@@ -241,14 +242,14 @@ func TestStackSerialization(t *testing.T) {
 }
 
 func TestStackString(t *testing.T) {
-	c := New[int]()
+	c := linkedliststack.New[int]()
 	c.Push(1)
 	if !strings.HasPrefix(c.String(), "LinkedListStack") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkPush(b *testing.B, stack *Stack[int], size int) {
+func benchmarkPush(b *testing.B, stack *linkedliststack.Stack[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			stack.Push(n)
@@ -256,7 +257,7 @@ func benchmarkPush(b *testing.B, stack *Stack[int], size int) {
 	}
 }
 
-func benchmarkPop(b *testing.B, stack *Stack[int], size int) {
+func benchmarkPop(b *testing.B, stack *linkedliststack.Stack[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			stack.Pop()
@@ -267,7 +268,7 @@ func benchmarkPop(b *testing.B, stack *Stack[int], size int) {
 func BenchmarkLinkedListStackPop100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -278,7 +279,7 @@ func BenchmarkLinkedListStackPop100(b *testing.B) {
 func BenchmarkLinkedListStackPop1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -289,7 +290,7 @@ func BenchmarkLinkedListStackPop1000(b *testing.B) {
 func BenchmarkLinkedListStackPop10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -300,7 +301,7 @@ func BenchmarkLinkedListStackPop10000(b *testing.B) {
 func BenchmarkLinkedListStackPop100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -311,7 +312,7 @@ func BenchmarkLinkedListStackPop100000(b *testing.B) {
 func BenchmarkLinkedListStackPush100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	b.StartTimer()
 	benchmarkPush(b, stack, size)
 }
@@ -319,7 +320,7 @@ func BenchmarkLinkedListStackPush100(b *testing.B) {
 func BenchmarkLinkedListStackPush1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -330,7 +331,7 @@ func BenchmarkLinkedListStackPush1000(b *testing.B) {
 func BenchmarkLinkedListStackPush10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}
@@ -341,7 +342,7 @@ func BenchmarkLinkedListStackPush10000(b *testing.B) {
 func BenchmarkLinkedListStackPush100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	stack := New[int]()
+	stack := linkedliststack.New[int]()
 	for n := 0; n < size; n++ {
 		stack.Push(n)
 	}

--- a/trees/avltree/avltree_test.go
+++ b/trees/avltree/avltree_test.go
@@ -1,17 +1,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package avltree
+package avltree_test
 
 import (
 	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/trees/avltree"
 )
 
 func TestAVLTreeGet(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 
 	if actualValue := tree.Size(); actualValue != 0 {
 		t.Errorf("Got %v expected %v", actualValue, 0)
@@ -55,7 +57,7 @@ func TestAVLTreeGet(t *testing.T) {
 }
 
 func TestAVLTreePut(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(5, "e")
 	tree.Put(6, "f")
 	tree.Put(7, "g")
@@ -96,7 +98,7 @@ func TestAVLTreePut(t *testing.T) {
 }
 
 func TestAVLTreeRemove(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(5, "e")
 	tree.Put(6, "f")
 	tree.Put(7, "g")
@@ -160,7 +162,7 @@ func TestAVLTreeRemove(t *testing.T) {
 }
 
 func TestAVLTreeLeftAndRight(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 
 	if actualValue := tree.Left(); actualValue != nil {
 		t.Errorf("Got %v expected %v", actualValue, nil)
@@ -194,7 +196,7 @@ func TestAVLTreeLeftAndRight(t *testing.T) {
 }
 
 func TestAVLTreeCeilingAndFloor(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 
 	if node, found := tree.Floor(0); node != nil || found {
 		t.Errorf("Got %v expected %v", node, "<nil>")
@@ -227,7 +229,7 @@ func TestAVLTreeCeilingAndFloor(t *testing.T) {
 }
 
 func TestAVLTreeIteratorNextOnEmpty(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	it := tree.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty tree")
@@ -235,7 +237,7 @@ func TestAVLTreeIteratorNextOnEmpty(t *testing.T) {
 }
 
 func TestAVLTreeIteratorPrevOnEmpty(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	it := tree.Iterator()
 	for it.Prev() {
 		t.Errorf("Shouldn't iterate on empty tree")
@@ -243,7 +245,7 @@ func TestAVLTreeIteratorPrevOnEmpty(t *testing.T) {
 }
 
 func TestAVLTreeIterator1Next(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(5, "e")
 	tree.Put(6, "f")
 	tree.Put(7, "g")
@@ -275,7 +277,7 @@ func TestAVLTreeIterator1Next(t *testing.T) {
 }
 
 func TestAVLTreeIterator1Prev(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(5, "e")
 	tree.Put(6, "f")
 	tree.Put(7, "g")
@@ -294,7 +296,7 @@ func TestAVLTreeIterator1Prev(t *testing.T) {
 	it := tree.Iterator()
 	for it.Next() {
 	}
-	countDown := tree.size
+	countDown := tree.Size()
 	for it.Prev() {
 		key := it.Key()
 		if actualValue, expectedValue := key, countDown; actualValue != expectedValue {
@@ -308,7 +310,7 @@ func TestAVLTreeIterator1Prev(t *testing.T) {
 }
 
 func TestAVLTreeIterator2Next(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
@@ -327,14 +329,14 @@ func TestAVLTreeIterator2Next(t *testing.T) {
 }
 
 func TestAVLTreeIterator2Prev(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
 	it := tree.Iterator()
 	for it.Next() {
 	}
-	countDown := tree.size
+	countDown := tree.Size()
 	for it.Prev() {
 		key := it.Key()
 		if actualValue, expectedValue := key, countDown; actualValue != expectedValue {
@@ -348,7 +350,7 @@ func TestAVLTreeIterator2Prev(t *testing.T) {
 }
 
 func TestAVLTreeIterator3Next(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(1, "a")
 	it := tree.Iterator()
 	count := 0
@@ -365,12 +367,12 @@ func TestAVLTreeIterator3Next(t *testing.T) {
 }
 
 func TestAVLTreeIterator3Prev(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(1, "a")
 	it := tree.Iterator()
 	for it.Next() {
 	}
-	countDown := tree.size
+	countDown := tree.Size()
 	for it.Prev() {
 		key := it.Key()
 		if actualValue, expectedValue := key, countDown; actualValue != expectedValue {
@@ -384,7 +386,7 @@ func TestAVLTreeIterator3Prev(t *testing.T) {
 }
 
 func TestAVLTreeIterator4Next(t *testing.T) {
-	tree := New[int, int]()
+	tree := avltree.New[int, int]()
 	tree.Put(13, 5)
 	tree.Put(8, 3)
 	tree.Put(17, 7)
@@ -420,7 +422,7 @@ func TestAVLTreeIterator4Next(t *testing.T) {
 }
 
 func TestAVLTreeIterator4Prev(t *testing.T) {
-	tree := New[int, int]()
+	tree := avltree.New[int, int]()
 	tree.Put(13, 5)
 	tree.Put(8, 3)
 	tree.Put(17, 7)
@@ -458,7 +460,7 @@ func TestAVLTreeIterator4Prev(t *testing.T) {
 }
 
 func TestAVLTreeIteratorBegin(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
@@ -490,7 +492,7 @@ func TestAVLTreeIteratorBegin(t *testing.T) {
 }
 
 func TestAVLTreeIteratorEnd(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	it := tree.Iterator()
 
 	if it.Key() != 0 {
@@ -517,7 +519,7 @@ func TestAVLTreeIteratorEnd(t *testing.T) {
 }
 
 func TestAVLTreeIteratorFirst(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
@@ -531,7 +533,7 @@ func TestAVLTreeIteratorFirst(t *testing.T) {
 }
 
 func TestAVLTreeIteratorLast(t *testing.T) {
-	tree := New[int, string]()
+	tree := avltree.New[int, string]()
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
@@ -552,7 +554,7 @@ func TestAVLTreeIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		tree := New[int, string]()
+		tree := avltree.New[int, string]()
 		it := tree.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty tree")
@@ -561,7 +563,7 @@ func TestAVLTreeIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		tree := New[int, string]()
+		tree := avltree.New[int, string]()
 		tree.Put(0, "xx")
 		tree.Put(1, "yy")
 		it := tree.Iterator()
@@ -572,7 +574,7 @@ func TestAVLTreeIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		tree := New[int, string]()
+		tree := avltree.New[int, string]()
 		tree.Put(2, "cc")
 		tree.Put(0, "aa")
 		tree.Put(1, "bb")
@@ -604,7 +606,7 @@ func TestAVLTreeIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		tree := New[int, string]()
+		tree := avltree.New[int, string]()
 		it := tree.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -614,7 +616,7 @@ func TestAVLTreeIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		tree := New[int, string]()
+		tree := avltree.New[int, string]()
 		tree.Put(0, "xx")
 		tree.Put(1, "yy")
 		it := tree.Iterator()
@@ -626,7 +628,7 @@ func TestAVLTreeIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		tree := New[int, string]()
+		tree := avltree.New[int, string]()
 		tree.Put(2, "cc")
 		tree.Put(0, "aa")
 		tree.Put(1, "bb")
@@ -651,7 +653,7 @@ func TestAVLTreeIteratorPrevTo(t *testing.T) {
 }
 
 func TestAVLTreeSerialization(t *testing.T) {
-	tree := New[string, string]()
+	tree := avltree.New[string, string]()
 	tree.Put("c", "3")
 	tree.Put("b", "2")
 	tree.Put("a", "1")
@@ -685,7 +687,7 @@ func TestAVLTreeSerialization(t *testing.T) {
 		t.Errorf("Got error %v", err)
 	}
 
-	intTree := New[string, int]()
+	intTree := avltree.New[string, int]()
 	err = json.Unmarshal([]byte(`{"a":1,"b":2}`), intTree)
 	if err != nil {
 		t.Errorf("Got error %v", err)
@@ -702,7 +704,7 @@ func TestAVLTreeSerialization(t *testing.T) {
 }
 
 func TestAVLTreeString(t *testing.T) {
-	c := New[int, int]()
+	c := avltree.New[int, int]()
 	c.Put(1, 1)
 	c.Put(2, 1)
 	c.Put(3, 1)
@@ -717,7 +719,7 @@ func TestAVLTreeString(t *testing.T) {
 	}
 }
 
-func benchmarkGet(b *testing.B, tree *Tree[int, struct{}], size int) {
+func benchmarkGet(b *testing.B, tree *avltree.Tree[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			tree.Get(n)
@@ -725,7 +727,7 @@ func benchmarkGet(b *testing.B, tree *Tree[int, struct{}], size int) {
 	}
 }
 
-func benchmarkPut(b *testing.B, tree *Tree[int, struct{}], size int) {
+func benchmarkPut(b *testing.B, tree *avltree.Tree[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			tree.Put(n, struct{}{})
@@ -733,7 +735,7 @@ func benchmarkPut(b *testing.B, tree *Tree[int, struct{}], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, tree *Tree[int, struct{}], size int) {
+func benchmarkRemove(b *testing.B, tree *avltree.Tree[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			tree.Remove(n)
@@ -744,7 +746,7 @@ func benchmarkRemove(b *testing.B, tree *Tree[int, struct{}], size int) {
 func BenchmarkAVLTreeGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -755,7 +757,7 @@ func BenchmarkAVLTreeGet100(b *testing.B) {
 func BenchmarkAVLTreeGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -766,7 +768,7 @@ func BenchmarkAVLTreeGet1000(b *testing.B) {
 func BenchmarkAVLTreeGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -777,7 +779,7 @@ func BenchmarkAVLTreeGet10000(b *testing.B) {
 func BenchmarkAVLTreeGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -788,7 +790,7 @@ func BenchmarkAVLTreeGet100000(b *testing.B) {
 func BenchmarkAVLTreePut100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	b.StartTimer()
 	benchmarkPut(b, tree, size)
 }
@@ -796,7 +798,7 @@ func BenchmarkAVLTreePut100(b *testing.B) {
 func BenchmarkAVLTreePut1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -807,7 +809,7 @@ func BenchmarkAVLTreePut1000(b *testing.B) {
 func BenchmarkAVLTreePut10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -818,7 +820,7 @@ func BenchmarkAVLTreePut10000(b *testing.B) {
 func BenchmarkAVLTreePut100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -829,7 +831,7 @@ func BenchmarkAVLTreePut100000(b *testing.B) {
 func BenchmarkAVLTreeRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -840,7 +842,7 @@ func BenchmarkAVLTreeRemove100(b *testing.B) {
 func BenchmarkAVLTreeRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -851,7 +853,7 @@ func BenchmarkAVLTreeRemove1000(b *testing.B) {
 func BenchmarkAVLTreeRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -862,7 +864,7 @@ func BenchmarkAVLTreeRemove10000(b *testing.B) {
 func BenchmarkAVLTreeRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	tree := New[int, struct{}]()
+	tree := avltree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}

--- a/trees/binaryheap/binaryheap_test.go
+++ b/trees/binaryheap/binaryheap_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package binaryheap
+package binaryheap_test
 
 import (
 	"encoding/json"
@@ -10,10 +10,12 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/trees/binaryheap"
 )
 
 func TestBinaryHeapPush(t *testing.T) {
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 
 	if actualValue := heap.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
@@ -38,7 +40,7 @@ func TestBinaryHeapPush(t *testing.T) {
 }
 
 func TestBinaryHeapPushBulk(t *testing.T) {
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 
 	heap.Push(15, 20, 3, 1, 2)
 
@@ -51,7 +53,7 @@ func TestBinaryHeapPushBulk(t *testing.T) {
 }
 
 func TestBinaryHeapPop(t *testing.T) {
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 
 	if actualValue := heap.Empty(); actualValue != true {
 		t.Errorf("Got %v expected %v", actualValue, true)
@@ -83,7 +85,7 @@ func TestBinaryHeapPop(t *testing.T) {
 }
 
 func TestBinaryHeapRandom(t *testing.T) {
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 
 	rand.Seed(3)
 	for i := 0; i < 10000; i++ {
@@ -102,7 +104,7 @@ func TestBinaryHeapRandom(t *testing.T) {
 }
 
 func TestBinaryHeapIteratorOnEmpty(t *testing.T) {
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	it := heap.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty heap")
@@ -110,7 +112,7 @@ func TestBinaryHeapIteratorOnEmpty(t *testing.T) {
 }
 
 func TestBinaryHeapIteratorNext(t *testing.T) {
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	heap.Push(3)
 	heap.Push(2)
 	heap.Push(1)
@@ -147,7 +149,7 @@ func TestBinaryHeapIteratorNext(t *testing.T) {
 }
 
 func TestBinaryHeapIteratorPrev(t *testing.T) {
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	heap.Push(3)
 	heap.Push(2)
 	heap.Push(1)
@@ -186,7 +188,7 @@ func TestBinaryHeapIteratorPrev(t *testing.T) {
 }
 
 func TestBinaryHeapIteratorBegin(t *testing.T) {
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	it := heap.Iterator()
 	it.Begin()
 	heap.Push(2)
@@ -202,7 +204,7 @@ func TestBinaryHeapIteratorBegin(t *testing.T) {
 }
 
 func TestBinaryHeapIteratorEnd(t *testing.T) {
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	it := heap.Iterator()
 
 	if index := it.Index(); index != -1 {
@@ -229,7 +231,7 @@ func TestBinaryHeapIteratorEnd(t *testing.T) {
 }
 
 func TestBinaryHeapIteratorFirst(t *testing.T) {
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	it := heap.Iterator()
 	if actualValue, expectedValue := it.First(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -246,7 +248,7 @@ func TestBinaryHeapIteratorFirst(t *testing.T) {
 }
 
 func TestBinaryHeapIteratorLast(t *testing.T) {
-	tree := New[int]()
+	tree := binaryheap.New[int]()
 	it := tree.Iterator()
 	if actualValue, expectedValue := it.Last(), false; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
@@ -270,7 +272,7 @@ func TestBinaryHeapIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		tree := New[string]()
+		tree := binaryheap.New[string]()
 		it := tree.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty list")
@@ -279,7 +281,7 @@ func TestBinaryHeapIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		tree := New[string]()
+		tree := binaryheap.New[string]()
 		tree.Push("xx")
 		tree.Push("yy")
 		it := tree.Iterator()
@@ -290,7 +292,7 @@ func TestBinaryHeapIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		tree := New[string]()
+		tree := binaryheap.New[string]()
 		tree.Push("aa")
 		tree.Push("bb")
 		tree.Push("cc")
@@ -322,7 +324,7 @@ func TestBinaryHeapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		tree := New[string]()
+		tree := binaryheap.New[string]()
 		it := tree.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -332,7 +334,7 @@ func TestBinaryHeapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		tree := New[string]()
+		tree := binaryheap.New[string]()
 		tree.Push("xx")
 		tree.Push("yy")
 		it := tree.Iterator()
@@ -344,7 +346,7 @@ func TestBinaryHeapIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		tree := New[string]()
+		tree := binaryheap.New[string]()
 		tree.Push("aa")
 		tree.Push("bb")
 		tree.Push("cc")
@@ -369,7 +371,7 @@ func TestBinaryHeapIteratorPrevTo(t *testing.T) {
 }
 
 func TestBinaryHeapSerialization(t *testing.T) {
-	heap := New[string]()
+	heap := binaryheap.New[string]()
 
 	heap.Push("c")
 	heap.Push("b")
@@ -404,7 +406,7 @@ func TestBinaryHeapSerialization(t *testing.T) {
 		t.Errorf("Got error %v", err)
 	}
 
-	intHeap := New[int]()
+	intHeap := binaryheap.New[int]()
 	err = json.Unmarshal([]byte(`[1,2,3]`), &intHeap)
 	if err != nil {
 		t.Errorf("Got error %v", err)
@@ -415,14 +417,14 @@ func TestBinaryHeapSerialization(t *testing.T) {
 }
 
 func TestBTreeString(t *testing.T) {
-	c := New[int]()
+	c := binaryheap.New[int]()
 	c.Push(1)
 	if !strings.HasPrefix(c.String(), "BinaryHeap") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkPush(b *testing.B, heap *Heap[int], size int) {
+func benchmarkPush(b *testing.B, heap *binaryheap.Heap[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			heap.Push(n)
@@ -430,7 +432,7 @@ func benchmarkPush(b *testing.B, heap *Heap[int], size int) {
 	}
 }
 
-func benchmarkPop(b *testing.B, heap *Heap[int], size int) {
+func benchmarkPop(b *testing.B, heap *binaryheap.Heap[int], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			heap.Pop()
@@ -441,7 +443,7 @@ func benchmarkPop(b *testing.B, heap *Heap[int], size int) {
 func BenchmarkBinaryHeapPop100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	for n := 0; n < size; n++ {
 		heap.Push(n)
 	}
@@ -452,7 +454,7 @@ func BenchmarkBinaryHeapPop100(b *testing.B) {
 func BenchmarkBinaryHeapPop1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	for n := 0; n < size; n++ {
 		heap.Push(n)
 	}
@@ -463,7 +465,7 @@ func BenchmarkBinaryHeapPop1000(b *testing.B) {
 func BenchmarkBinaryHeapPop10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	for n := 0; n < size; n++ {
 		heap.Push(n)
 	}
@@ -474,7 +476,7 @@ func BenchmarkBinaryHeapPop10000(b *testing.B) {
 func BenchmarkBinaryHeapPop100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	for n := 0; n < size; n++ {
 		heap.Push(n)
 	}
@@ -485,7 +487,7 @@ func BenchmarkBinaryHeapPop100000(b *testing.B) {
 func BenchmarkBinaryHeapPush100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	b.StartTimer()
 	benchmarkPush(b, heap, size)
 }
@@ -493,7 +495,7 @@ func BenchmarkBinaryHeapPush100(b *testing.B) {
 func BenchmarkBinaryHeapPush1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	for n := 0; n < size; n++ {
 		heap.Push(n)
 	}
@@ -504,7 +506,7 @@ func BenchmarkBinaryHeapPush1000(b *testing.B) {
 func BenchmarkBinaryHeapPush10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	for n := 0; n < size; n++ {
 		heap.Push(n)
 	}
@@ -515,7 +517,7 @@ func BenchmarkBinaryHeapPush10000(b *testing.B) {
 func BenchmarkBinaryHeapPush100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	heap := New[int]()
+	heap := binaryheap.New[int]()
 	for n := 0; n < size; n++ {
 		heap.Push(n)
 	}

--- a/trees/btree/btree_test.go
+++ b/trees/btree/btree_test.go
@@ -2,17 +2,19 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package btree
+package btree_test
 
 import (
 	"encoding/json"
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/trees/btree"
 )
 
 func TestBTreeGet1(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(1, "a")
 	tree.Put(2, "b")
 	tree.Put(3, "c")
@@ -41,7 +43,7 @@ func TestBTreeGet1(t *testing.T) {
 }
 
 func TestBTreeGet2(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(7, "g")
 	tree.Put(9, "i")
 	tree.Put(10, "j")
@@ -76,7 +78,7 @@ func TestBTreeGet2(t *testing.T) {
 }
 
 func TestBTreeGet3(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 
 	if actualValue := tree.Size(); actualValue != 0 {
 		t.Errorf("Got %v expected %v", actualValue, 0)
@@ -123,7 +125,7 @@ func TestBTreeGet3(t *testing.T) {
 
 func TestBTreePut1(t *testing.T) {
 	// https://upload.wikimedia.org/wikipedia/commons/3/33/B_tree_insertion_example.png
-	tree := New[int, int](3)
+	tree := btree.New[int, int](3)
 	assertValidTree(t, tree, 0)
 
 	tree.Put(1, 0)
@@ -172,7 +174,7 @@ func TestBTreePut1(t *testing.T) {
 }
 
 func TestBTreePut2(t *testing.T) {
-	tree := New[int, int](4)
+	tree := btree.New[int, int](4)
 	assertValidTree(t, tree, 0)
 
 	tree.Put(0, 0)
@@ -213,7 +215,7 @@ func TestBTreePut2(t *testing.T) {
 
 func TestBTreePut3(t *testing.T) {
 	// http://www.geeksforgeeks.org/b-tree-set-1-insert-2/
-	tree := New[int, int](6)
+	tree := btree.New[int, int](6)
 	assertValidTree(t, tree, 0)
 
 	tree.Put(10, 0)
@@ -263,7 +265,7 @@ func TestBTreePut3(t *testing.T) {
 }
 
 func TestBTreePut4(t *testing.T) {
-	tree := New[int, *struct{}](3)
+	tree := btree.New[int, *struct{}](3)
 	assertValidTree(t, tree, 0)
 
 	tree.Put(6, nil)
@@ -358,14 +360,14 @@ func TestBTreePut4(t *testing.T) {
 
 func TestBTreeRemove1(t *testing.T) {
 	// empty
-	tree := New[int, int](3)
+	tree := btree.New[int, int](3)
 	tree.Remove(1)
 	assertValidTree(t, tree, 0)
 }
 
 func TestBTreeRemove2(t *testing.T) {
 	// leaf node (no underflow)
-	tree := New[int, *struct{}](3)
+	tree := btree.New[int, *struct{}](3)
 	tree.Put(1, nil)
 	tree.Put(2, nil)
 
@@ -380,7 +382,7 @@ func TestBTreeRemove2(t *testing.T) {
 func TestBTreeRemove3(t *testing.T) {
 	// merge with right (underflow)
 	{
-		tree := New[int, *struct{}](3)
+		tree := btree.New[int, *struct{}](3)
 		tree.Put(1, nil)
 		tree.Put(2, nil)
 		tree.Put(3, nil)
@@ -391,7 +393,7 @@ func TestBTreeRemove3(t *testing.T) {
 	}
 	// merge with left (underflow)
 	{
-		tree := New[int, *struct{}](3)
+		tree := btree.New[int, *struct{}](3)
 		tree.Put(1, nil)
 		tree.Put(2, nil)
 		tree.Put(3, nil)
@@ -404,7 +406,7 @@ func TestBTreeRemove3(t *testing.T) {
 
 func TestBTreeRemove4(t *testing.T) {
 	// rotate left (underflow)
-	tree := New[int, *struct{}](3)
+	tree := btree.New[int, *struct{}](3)
 	tree.Put(1, nil)
 	tree.Put(2, nil)
 	tree.Put(3, nil)
@@ -424,7 +426,7 @@ func TestBTreeRemove4(t *testing.T) {
 
 func TestBTreeRemove5(t *testing.T) {
 	// rotate right (underflow)
-	tree := New[int, *struct{}](3)
+	tree := btree.New[int, *struct{}](3)
 	tree.Put(1, nil)
 	tree.Put(2, nil)
 	tree.Put(3, nil)
@@ -445,7 +447,7 @@ func TestBTreeRemove5(t *testing.T) {
 func TestBTreeRemove6(t *testing.T) {
 	// root height reduction after a series of underflows on right side
 	// use simulator: https://www.cs.usfca.edu/~galles/visualization/BTree.html
-	tree := New[int, *struct{}](3)
+	tree := btree.New[int, *struct{}](3)
 	tree.Put(1, nil)
 	tree.Put(2, nil)
 	tree.Put(3, nil)
@@ -474,7 +476,7 @@ func TestBTreeRemove6(t *testing.T) {
 func TestBTreeRemove7(t *testing.T) {
 	// root height reduction after a series of underflows on left side
 	// use simulator: https://www.cs.usfca.edu/~galles/visualization/BTree.html
-	tree := New[int, *struct{}](3)
+	tree := btree.New[int, *struct{}](3)
 	tree.Put(1, nil)
 	tree.Put(2, nil)
 	tree.Put(3, nil)
@@ -533,7 +535,7 @@ func TestBTreeRemove7(t *testing.T) {
 
 func TestBTreeRemove8(t *testing.T) {
 	// use simulator: https://www.cs.usfca.edu/~galles/visualization/BTree.html
-	tree := New[int, *struct{}](3)
+	tree := btree.New[int, *struct{}](3)
 	tree.Put(1, nil)
 	tree.Put(2, nil)
 	tree.Put(3, nil)
@@ -570,7 +572,7 @@ func TestBTreeRemove9(t *testing.T) {
 	orders := []int{3, 4, 5, 6, 7, 8, 9, 10, 20, 100, 500, 1000, 5000, 10000}
 	for _, order := range orders {
 
-		tree := New[int, int](order)
+		tree := btree.New[int, int](order)
 
 		{
 			for i := 1; i <= max; i++ {
@@ -611,7 +613,7 @@ func TestBTreeRemove9(t *testing.T) {
 }
 
 func TestBTreeHeight(t *testing.T) {
-	tree := New[int, int](3)
+	tree := btree.New[int, int](3)
 	if actualValue, expectedValue := tree.Height(), 0; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v", actualValue, expectedValue)
 	}
@@ -664,7 +666,7 @@ func TestBTreeHeight(t *testing.T) {
 }
 
 func TestBTreeLeftAndRight(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 
 	if actualValue := tree.Left(); actualValue != nil {
 		t.Errorf("Got %v expected %v", actualValue, nil)
@@ -698,7 +700,7 @@ func TestBTreeLeftAndRight(t *testing.T) {
 }
 
 func TestBTreeIteratorValuesAndKeys(t *testing.T) {
-	tree := New[int, string](4)
+	tree := btree.New[int, string](4)
 	tree.Put(4, "d")
 	tree.Put(5, "e")
 	tree.Put(6, "f")
@@ -719,7 +721,7 @@ func TestBTreeIteratorValuesAndKeys(t *testing.T) {
 }
 
 func TestBTreeIteratorNextOnEmpty(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	it := tree.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty tree")
@@ -727,7 +729,7 @@ func TestBTreeIteratorNextOnEmpty(t *testing.T) {
 }
 
 func TestBTreeIteratorPrevOnEmpty(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	it := tree.Iterator()
 	for it.Prev() {
 		t.Errorf("Shouldn't iterate on empty tree")
@@ -735,7 +737,7 @@ func TestBTreeIteratorPrevOnEmpty(t *testing.T) {
 }
 
 func TestBTreeIterator1Next(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(5, "e")
 	tree.Put(6, "f")
 	tree.Put(7, "g")
@@ -759,7 +761,7 @@ func TestBTreeIterator1Next(t *testing.T) {
 }
 
 func TestBTreeIterator1Prev(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(5, "e")
 	tree.Put(6, "f")
 	tree.Put(7, "g")
@@ -771,7 +773,7 @@ func TestBTreeIterator1Prev(t *testing.T) {
 	it := tree.Iterator()
 	for it.Next() {
 	}
-	countDown := tree.size
+	countDown := tree.Size()
 	for it.Prev() {
 		key := it.Key()
 		if actualValue, expectedValue := key, countDown; actualValue != expectedValue {
@@ -785,7 +787,7 @@ func TestBTreeIterator1Prev(t *testing.T) {
 }
 
 func TestBTreeIterator2Next(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
@@ -804,14 +806,14 @@ func TestBTreeIterator2Next(t *testing.T) {
 }
 
 func TestBTreeIterator2Prev(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
 	it := tree.Iterator()
 	for it.Next() {
 	}
-	countDown := tree.size
+	countDown := tree.Size()
 	for it.Prev() {
 		key := it.Key()
 		if actualValue, expectedValue := key, countDown; actualValue != expectedValue {
@@ -825,7 +827,7 @@ func TestBTreeIterator2Prev(t *testing.T) {
 }
 
 func TestBTreeIterator3Next(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(1, "a")
 	it := tree.Iterator()
 	count := 0
@@ -842,12 +844,12 @@ func TestBTreeIterator3Next(t *testing.T) {
 }
 
 func TestBTreeIterator3Prev(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(1, "a")
 	it := tree.Iterator()
 	for it.Next() {
 	}
-	countDown := tree.size
+	countDown := tree.Size()
 	for it.Prev() {
 		key := it.Key()
 		if actualValue, expectedValue := key, countDown; actualValue != expectedValue {
@@ -861,7 +863,7 @@ func TestBTreeIterator3Prev(t *testing.T) {
 }
 
 func TestBTreeIterator4Next(t *testing.T) {
-	tree := New[int, int](3)
+	tree := btree.New[int, int](3)
 	tree.Put(13, 5)
 	tree.Put(8, 3)
 	tree.Put(17, 7)
@@ -887,7 +889,7 @@ func TestBTreeIterator4Next(t *testing.T) {
 }
 
 func TestBTreeIterator4Prev(t *testing.T) {
-	tree := New[int, int](3)
+	tree := btree.New[int, int](3)
 	tree.Put(13, 5)
 	tree.Put(8, 3)
 	tree.Put(17, 7)
@@ -915,20 +917,20 @@ func TestBTreeIterator4Prev(t *testing.T) {
 }
 
 func TestBTreeIteratorBegin(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
 	it := tree.Iterator()
 
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	it.Begin()
 
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	for it.Next() {
@@ -936,8 +938,8 @@ func TestBTreeIteratorBegin(t *testing.T) {
 
 	it.Begin()
 
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	it.Next()
@@ -947,24 +949,24 @@ func TestBTreeIteratorBegin(t *testing.T) {
 }
 
 func TestBTreeIteratorEnd(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	it := tree.Iterator()
 
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	it.End()
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
 	it.End()
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	it.Prev()
@@ -974,7 +976,7 @@ func TestBTreeIteratorEnd(t *testing.T) {
 }
 
 func TestBTreeIteratorFirst(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
@@ -988,7 +990,7 @@ func TestBTreeIteratorFirst(t *testing.T) {
 }
 
 func TestBTreeIteratorLast(t *testing.T) {
-	tree := New[int, string](3)
+	tree := btree.New[int, string](3)
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
@@ -1003,14 +1005,13 @@ func TestBTreeIteratorLast(t *testing.T) {
 
 func TestBTreeSearch(t *testing.T) {
 	{
-		tree := New[int, int](3)
-		tree.Root = &Node[int, int]{Entries: []*Entry[int, int]{}, Children: make([]*Node[int, int], 0)}
+		tree := btree.New[int, int](3)
 		tests := [][]interface{}{
 			{0, 0, false},
 		}
 		for _, test := range tests {
-			index, found := tree.search(tree.Root, test[0].(int))
-			if actualValue, expectedValue := index, test[1]; actualValue != expectedValue {
+			value, found := tree.Get(test[0].(int))
+			if actualValue, expectedValue := value, test[1]; actualValue != expectedValue {
 				t.Errorf("Got %v expected %v", actualValue, expectedValue)
 			}
 			if actualValue, expectedValue := found, test[2]; actualValue != expectedValue {
@@ -1019,37 +1020,39 @@ func TestBTreeSearch(t *testing.T) {
 		}
 	}
 	{
-		tree := New[int, int](3)
-		tree.Root = &Node[int, int]{Entries: []*Entry[int, int]{{2, 0}, {4, 1}, {6, 2}}, Children: []*Node[int, int]{}}
+		tree := btree.New[int, int](3)
+		tree.Put(2, 0)
+		tree.Put(4, 1)
+		tree.Put(6, 2)
 		tests := [][]interface{}{
 			{0, 0, false},
 			{1, 0, false},
 			{2, 0, true},
-			{3, 1, false},
+			{3, 0, false},
 			{4, 1, true},
-			{5, 2, false},
+			{5, 0, false},
 			{6, 2, true},
-			{7, 3, false},
+			{7, 0, false},
 		}
 		for _, test := range tests {
-			index, found := tree.search(tree.Root, test[0].(int))
-			if actualValue, expectedValue := index, test[1]; actualValue != expectedValue {
-				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+			value, found := tree.Get(test[0].(int))
+			if actualValue, expectedValue := value, test[1]; actualValue != expectedValue {
+				t.Errorf("Got %v expected %v at %v", actualValue, expectedValue, test[0])
 			}
 			if actualValue, expectedValue := found, test[2]; actualValue != expectedValue {
-				t.Errorf("Got %v expected %v", actualValue, expectedValue)
+				t.Errorf("Got %v expected %v at %v", actualValue, expectedValue, test[0])
 			}
 		}
 	}
 }
 
-func assertValidTree[K comparable, V any](t *testing.T, tree *Tree[K, V], expectedSize int) {
-	if actualValue, expectedValue := tree.size, expectedSize; actualValue != expectedValue {
+func assertValidTree[K comparable, V any](t *testing.T, tree *btree.Tree[K, V], expectedSize int) {
+	if actualValue, expectedValue := tree.Size(), expectedSize; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v for tree size", actualValue, expectedValue)
 	}
 }
 
-func assertValidTreeNode[K comparable, V any](t *testing.T, node *Node[K, V], expectedEntries int, expectedChildren int, keys []K, hasParent bool) {
+func assertValidTreeNode[K comparable, V any](t *testing.T, node *btree.Node[K, V], expectedEntries int, expectedChildren int, keys []K, hasParent bool) {
 	if actualValue, expectedValue := node.Parent != nil, hasParent; actualValue != expectedValue {
 		t.Errorf("Got %v expected %v for hasParent", actualValue, expectedValue)
 	}
@@ -1074,7 +1077,7 @@ func TestBTreeIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		tree := New[int, string](3)
+		tree := btree.New[int, string](3)
 		it := tree.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty tree")
@@ -1083,7 +1086,7 @@ func TestBTreeIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		tree := New[int, string](3)
+		tree := btree.New[int, string](3)
 		tree.Put(0, "xx")
 		tree.Put(1, "yy")
 		it := tree.Iterator()
@@ -1094,7 +1097,7 @@ func TestBTreeIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		tree := New[int, string](3)
+		tree := btree.New[int, string](3)
 		tree.Put(2, "cc")
 		tree.Put(0, "aa")
 		tree.Put(1, "bb")
@@ -1126,7 +1129,7 @@ func TestBTreeIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		tree := New[int, string](3)
+		tree := btree.New[int, string](3)
 		it := tree.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -1136,7 +1139,7 @@ func TestBTreeIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		tree := New[int, string](3)
+		tree := btree.New[int, string](3)
 		tree.Put(0, "xx")
 		tree.Put(1, "yy")
 		it := tree.Iterator()
@@ -1148,7 +1151,7 @@ func TestBTreeIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		tree := New[int, string](3)
+		tree := btree.New[int, string](3)
 		tree.Put(2, "cc")
 		tree.Put(0, "aa")
 		tree.Put(1, "bb")
@@ -1173,7 +1176,7 @@ func TestBTreeIteratorPrevTo(t *testing.T) {
 }
 
 func TestBTreeSerialization(t *testing.T) {
-	tree := New[string, string](3)
+	tree := btree.New[string, string](3)
 	tree.Put("c", "3")
 	tree.Put("b", "2")
 	tree.Put("a", "1")
@@ -1207,7 +1210,7 @@ func TestBTreeSerialization(t *testing.T) {
 		t.Errorf("Got error %v", err)
 	}
 
-	intTree := New[string, int](3)
+	intTree := btree.New[string, int](3)
 	err = json.Unmarshal([]byte(`{"a":1,"b":2}`), intTree)
 	if err != nil {
 		t.Errorf("Got error %v", err)
@@ -1224,14 +1227,14 @@ func TestBTreeSerialization(t *testing.T) {
 }
 
 func TestBTreeString(t *testing.T) {
-	c := New[string, int](3)
+	c := btree.New[string, int](3)
 	c.Put("a", 1)
 	if !strings.HasPrefix(c.String(), "BTree") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkGet(b *testing.B, tree *Tree[int, struct{}], size int) {
+func benchmarkGet(b *testing.B, tree *btree.Tree[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			tree.Get(n)
@@ -1239,7 +1242,7 @@ func benchmarkGet(b *testing.B, tree *Tree[int, struct{}], size int) {
 	}
 }
 
-func benchmarkPut(b *testing.B, tree *Tree[int, struct{}], size int) {
+func benchmarkPut(b *testing.B, tree *btree.Tree[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			tree.Put(n, struct{}{})
@@ -1247,7 +1250,7 @@ func benchmarkPut(b *testing.B, tree *Tree[int, struct{}], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, tree *Tree[int, struct{}], size int) {
+func benchmarkRemove(b *testing.B, tree *btree.Tree[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			tree.Remove(n)
@@ -1258,7 +1261,7 @@ func benchmarkRemove(b *testing.B, tree *Tree[int, struct{}], size int) {
 func BenchmarkBTreeGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -1269,7 +1272,7 @@ func BenchmarkBTreeGet100(b *testing.B) {
 func BenchmarkBTreeGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -1280,7 +1283,7 @@ func BenchmarkBTreeGet1000(b *testing.B) {
 func BenchmarkBTreeGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -1291,7 +1294,7 @@ func BenchmarkBTreeGet10000(b *testing.B) {
 func BenchmarkBTreeGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -1302,7 +1305,7 @@ func BenchmarkBTreeGet100000(b *testing.B) {
 func BenchmarkBTreePut100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	b.StartTimer()
 	benchmarkPut(b, tree, size)
 }
@@ -1310,7 +1313,7 @@ func BenchmarkBTreePut100(b *testing.B) {
 func BenchmarkBTreePut1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -1321,7 +1324,7 @@ func BenchmarkBTreePut1000(b *testing.B) {
 func BenchmarkBTreePut10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -1332,7 +1335,7 @@ func BenchmarkBTreePut10000(b *testing.B) {
 func BenchmarkBTreePut100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -1343,7 +1346,7 @@ func BenchmarkBTreePut100000(b *testing.B) {
 func BenchmarkBTreeRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -1354,7 +1357,7 @@ func BenchmarkBTreeRemove100(b *testing.B) {
 func BenchmarkBTreeRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -1365,7 +1368,7 @@ func BenchmarkBTreeRemove1000(b *testing.B) {
 func BenchmarkBTreeRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -1376,7 +1379,7 @@ func BenchmarkBTreeRemove10000(b *testing.B) {
 func BenchmarkBTreeRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	tree := New[int, struct{}](128)
+	tree := btree.New[int, struct{}](128)
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}

--- a/trees/redblacktree/redblacktree_test.go
+++ b/trees/redblacktree/redblacktree_test.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package redblacktree
+package redblacktree_test
 
 import (
 	"encoding/json"
@@ -10,10 +10,12 @@ import (
 	"slices"
 	"strings"
 	"testing"
+
+	"github.com/emirpasic/gods/v2/trees/redblacktree"
 )
 
 func TestRedBlackTreeGet(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 
 	if actualValue := tree.Size(); actualValue != 0 {
 		t.Errorf("Got %v expected %v", actualValue, 0)
@@ -59,7 +61,7 @@ func TestRedBlackTreeGet(t *testing.T) {
 }
 
 func TestRedBlackTreePut(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(5, "e")
 	tree.Put(6, "f")
 	tree.Put(7, "g")
@@ -100,7 +102,7 @@ func TestRedBlackTreePut(t *testing.T) {
 }
 
 func TestRedBlackTreeRemove(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(5, "e")
 	tree.Put(6, "f")
 	tree.Put(7, "g")
@@ -164,7 +166,7 @@ func TestRedBlackTreeRemove(t *testing.T) {
 }
 
 func TestRedBlackTreeLeftAndRight(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 
 	if actualValue := tree.Left(); actualValue != nil {
 		t.Errorf("Got %v expected %v", actualValue, nil)
@@ -198,7 +200,7 @@ func TestRedBlackTreeLeftAndRight(t *testing.T) {
 }
 
 func TestRedBlackTreeCeilingAndFloor(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 
 	if node, found := tree.Floor(0); node != nil || found {
 		t.Errorf("Got %v expected %v", node, "<nil>")
@@ -231,7 +233,7 @@ func TestRedBlackTreeCeilingAndFloor(t *testing.T) {
 }
 
 func TestRedBlackTreeIteratorNextOnEmpty(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	it := tree.Iterator()
 	for it.Next() {
 		t.Errorf("Shouldn't iterate on empty tree")
@@ -239,7 +241,7 @@ func TestRedBlackTreeIteratorNextOnEmpty(t *testing.T) {
 }
 
 func TestRedBlackTreeIteratorPrevOnEmpty(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	it := tree.Iterator()
 	for it.Prev() {
 		t.Errorf("Shouldn't iterate on empty tree")
@@ -247,7 +249,7 @@ func TestRedBlackTreeIteratorPrevOnEmpty(t *testing.T) {
 }
 
 func TestRedBlackTreeIterator1Next(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(5, "e")
 	tree.Put(6, "f")
 	tree.Put(7, "g")
@@ -278,7 +280,7 @@ func TestRedBlackTreeIterator1Next(t *testing.T) {
 }
 
 func TestRedBlackTreeIterator1Prev(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(5, "e")
 	tree.Put(6, "f")
 	tree.Put(7, "g")
@@ -297,7 +299,7 @@ func TestRedBlackTreeIterator1Prev(t *testing.T) {
 	it := tree.Iterator()
 	for it.Next() {
 	}
-	countDown := tree.size
+	countDown := tree.Size()
 	for it.Prev() {
 		key := it.Key()
 		if actualValue, expectedValue := key, countDown; actualValue != expectedValue {
@@ -311,7 +313,7 @@ func TestRedBlackTreeIterator1Prev(t *testing.T) {
 }
 
 func TestRedBlackTreeIterator2Next(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
@@ -330,14 +332,14 @@ func TestRedBlackTreeIterator2Next(t *testing.T) {
 }
 
 func TestRedBlackTreeIterator2Prev(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
 	it := tree.Iterator()
 	for it.Next() {
 	}
-	countDown := tree.size
+	countDown := tree.Size()
 	for it.Prev() {
 		key := it.Key()
 		if actualValue, expectedValue := key, countDown; actualValue != expectedValue {
@@ -351,7 +353,7 @@ func TestRedBlackTreeIterator2Prev(t *testing.T) {
 }
 
 func TestRedBlackTreeIterator3Next(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(1, "a")
 	it := tree.Iterator()
 	count := 0
@@ -368,12 +370,12 @@ func TestRedBlackTreeIterator3Next(t *testing.T) {
 }
 
 func TestRedBlackTreeIterator3Prev(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(1, "a")
 	it := tree.Iterator()
 	for it.Next() {
 	}
-	countDown := tree.size
+	countDown := tree.Size()
 	for it.Prev() {
 		key := it.Key()
 		if actualValue, expectedValue := key, countDown; actualValue != expectedValue {
@@ -387,7 +389,7 @@ func TestRedBlackTreeIterator3Prev(t *testing.T) {
 }
 
 func TestRedBlackTreeIterator4Next(t *testing.T) {
-	tree := New[int, int]()
+	tree := redblacktree.New[int, int]()
 	tree.Put(13, 5)
 	tree.Put(8, 3)
 	tree.Put(17, 7)
@@ -423,7 +425,7 @@ func TestRedBlackTreeIterator4Next(t *testing.T) {
 }
 
 func TestRedBlackTreeIterator4Prev(t *testing.T) {
-	tree := New[int, int]()
+	tree := redblacktree.New[int, int]()
 	tree.Put(13, 5)
 	tree.Put(8, 3)
 	tree.Put(17, 7)
@@ -461,20 +463,20 @@ func TestRedBlackTreeIterator4Prev(t *testing.T) {
 }
 
 func TestRedBlackTreeIteratorBegin(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
 	it := tree.Iterator()
 
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	it.Begin()
 
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	for it.Next() {
@@ -482,8 +484,8 @@ func TestRedBlackTreeIteratorBegin(t *testing.T) {
 
 	it.Begin()
 
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	it.Next()
@@ -493,24 +495,24 @@ func TestRedBlackTreeIteratorBegin(t *testing.T) {
 }
 
 func TestRedBlackTreeIteratorEnd(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	it := tree.Iterator()
 
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	it.End()
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
 	it.End()
-	if it.node != nil {
-		t.Errorf("Got %v expected %v", it.node, nil)
+	if it.Node() != nil {
+		t.Errorf("Got %v expected %v", it.Node(), nil)
 	}
 
 	it.Prev()
@@ -520,7 +522,7 @@ func TestRedBlackTreeIteratorEnd(t *testing.T) {
 }
 
 func TestRedBlackTreeIteratorFirst(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
@@ -534,7 +536,7 @@ func TestRedBlackTreeIteratorFirst(t *testing.T) {
 }
 
 func TestRedBlackTreeIteratorLast(t *testing.T) {
-	tree := New[int, string]()
+	tree := redblacktree.New[int, string]()
 	tree.Put(3, "c")
 	tree.Put(1, "a")
 	tree.Put(2, "b")
@@ -555,7 +557,7 @@ func TestRedBlackTreeIteratorNextTo(t *testing.T) {
 
 	// NextTo (empty)
 	{
-		tree := New[int, string]()
+		tree := redblacktree.New[int, string]()
 		it := tree.Iterator()
 		for it.NextTo(seek) {
 			t.Errorf("Shouldn't iterate on empty tree")
@@ -564,7 +566,7 @@ func TestRedBlackTreeIteratorNextTo(t *testing.T) {
 
 	// NextTo (not found)
 	{
-		tree := New[int, string]()
+		tree := redblacktree.New[int, string]()
 		tree.Put(0, "xx")
 		tree.Put(1, "yy")
 		it := tree.Iterator()
@@ -575,7 +577,7 @@ func TestRedBlackTreeIteratorNextTo(t *testing.T) {
 
 	// NextTo (found)
 	{
-		tree := New[int, string]()
+		tree := redblacktree.New[int, string]()
 		tree.Put(2, "cc")
 		tree.Put(0, "aa")
 		tree.Put(1, "bb")
@@ -607,7 +609,7 @@ func TestRedBlackTreeIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (empty)
 	{
-		tree := New[int, string]()
+		tree := redblacktree.New[int, string]()
 		it := tree.Iterator()
 		it.End()
 		for it.PrevTo(seek) {
@@ -617,7 +619,7 @@ func TestRedBlackTreeIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (not found)
 	{
-		tree := New[int, string]()
+		tree := redblacktree.New[int, string]()
 		tree.Put(0, "xx")
 		tree.Put(1, "yy")
 		it := tree.Iterator()
@@ -629,7 +631,7 @@ func TestRedBlackTreeIteratorPrevTo(t *testing.T) {
 
 	// PrevTo (found)
 	{
-		tree := New[int, string]()
+		tree := redblacktree.New[int, string]()
 		tree.Put(2, "cc")
 		tree.Put(0, "aa")
 		tree.Put(1, "bb")
@@ -654,7 +656,7 @@ func TestRedBlackTreeIteratorPrevTo(t *testing.T) {
 }
 
 func TestRedBlackTreeSerialization(t *testing.T) {
-	tree := New[string, string]()
+	tree := redblacktree.New[string, string]()
 	tree.Put("c", "3")
 	tree.Put("b", "2")
 	tree.Put("a", "1")
@@ -688,7 +690,7 @@ func TestRedBlackTreeSerialization(t *testing.T) {
 		t.Errorf("Got error %v", err)
 	}
 
-	intTree := New[string, int]()
+	intTree := redblacktree.New[string, int]()
 	err = json.Unmarshal([]byte(`{"a":1,"b":2}`), intTree)
 	if err != nil {
 		t.Errorf("Got error %v", err)
@@ -705,14 +707,14 @@ func TestRedBlackTreeSerialization(t *testing.T) {
 }
 
 func TestRedBlackTreeString(t *testing.T) {
-	c := New[string, int]()
+	c := redblacktree.New[string, int]()
 	c.Put("a", 1)
 	if !strings.HasPrefix(c.String(), "RedBlackTree") {
 		t.Errorf("String should start with container name")
 	}
 }
 
-func benchmarkGet(b *testing.B, tree *Tree[int, struct{}], size int) {
+func benchmarkGet(b *testing.B, tree *redblacktree.Tree[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			tree.Get(n)
@@ -720,7 +722,7 @@ func benchmarkGet(b *testing.B, tree *Tree[int, struct{}], size int) {
 	}
 }
 
-func benchmarkPut(b *testing.B, tree *Tree[int, struct{}], size int) {
+func benchmarkPut(b *testing.B, tree *redblacktree.Tree[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			tree.Put(n, struct{}{})
@@ -728,7 +730,7 @@ func benchmarkPut(b *testing.B, tree *Tree[int, struct{}], size int) {
 	}
 }
 
-func benchmarkRemove(b *testing.B, tree *Tree[int, struct{}], size int) {
+func benchmarkRemove(b *testing.B, tree *redblacktree.Tree[int, struct{}], size int) {
 	for i := 0; i < b.N; i++ {
 		for n := 0; n < size; n++ {
 			tree.Remove(n)
@@ -739,7 +741,7 @@ func benchmarkRemove(b *testing.B, tree *Tree[int, struct{}], size int) {
 func BenchmarkRedBlackTreeGet100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -750,7 +752,7 @@ func BenchmarkRedBlackTreeGet100(b *testing.B) {
 func BenchmarkRedBlackTreeGet1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -761,7 +763,7 @@ func BenchmarkRedBlackTreeGet1000(b *testing.B) {
 func BenchmarkRedBlackTreeGet10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -772,7 +774,7 @@ func BenchmarkRedBlackTreeGet10000(b *testing.B) {
 func BenchmarkRedBlackTreeGet100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -783,7 +785,7 @@ func BenchmarkRedBlackTreeGet100000(b *testing.B) {
 func BenchmarkRedBlackTreePut100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	b.StartTimer()
 	benchmarkPut(b, tree, size)
 }
@@ -791,7 +793,7 @@ func BenchmarkRedBlackTreePut100(b *testing.B) {
 func BenchmarkRedBlackTreePut1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -802,7 +804,7 @@ func BenchmarkRedBlackTreePut1000(b *testing.B) {
 func BenchmarkRedBlackTreePut10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -813,7 +815,7 @@ func BenchmarkRedBlackTreePut10000(b *testing.B) {
 func BenchmarkRedBlackTreePut100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -824,7 +826,7 @@ func BenchmarkRedBlackTreePut100000(b *testing.B) {
 func BenchmarkRedBlackTreeRemove100(b *testing.B) {
 	b.StopTimer()
 	size := 100
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -835,7 +837,7 @@ func BenchmarkRedBlackTreeRemove100(b *testing.B) {
 func BenchmarkRedBlackTreeRemove1000(b *testing.B) {
 	b.StopTimer()
 	size := 1000
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -846,7 +848,7 @@ func BenchmarkRedBlackTreeRemove1000(b *testing.B) {
 func BenchmarkRedBlackTreeRemove10000(b *testing.B) {
 	b.StopTimer()
 	size := 10000
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}
@@ -857,7 +859,7 @@ func BenchmarkRedBlackTreeRemove10000(b *testing.B) {
 func BenchmarkRedBlackTreeRemove100000(b *testing.B) {
 	b.StopTimer()
 	size := 100000
-	tree := New[int, struct{}]()
+	tree := redblacktree.New[int, struct{}]()
 	for n := 0; n < size; n++ {
 		tree.Put(n, struct{}{})
 	}


### PR DESCRIPTION
As described in https://github.com/emirpasic/gods/issues/272, simple adoption of the `_test` package to enforce testing strictly against the public data structure APIs

Previous tests have been confirmed to still pass with updated imports

Only test that needed additional updates was inside `btree_test.go`, which was the only test that broke convention by testing unexported fields beyond simple reads (see `TestBTreeSearch()`)

The intended test behavior has been replicated as closely as possible using exported methods