### PR TITLE
avltree: add IteratorAt

### DIFF
--- a/trees/avltree/iterator.go
+++ b/trees/avltree/iterator.go
@@ -27,6 +27,11 @@ func (tree *Tree[K, V]) Iterator() *Iterator[K, V] {
 	return &Iterator[K, V]{tree: tree, node: nil, position: begin}
 }
 
+// IteratorAt returns a stateful iterator whose elements are key/value pairs that is initialised at a particular node.
+func (tree *Tree[K, V]) IteratorAt(node *Node[K, V]) *Iterator[K, V] {
+	return &Iterator[K, V]{tree: tree, node: node, position: between}
+}
+
 // Next moves the iterator to the next element and returns true if there was a next element in the container.
 // If Next() returns true, then next element's key and value can be retrieved by Key() and Value().
 // If Next() was called for the first time, then it will point the iterator to the first element if it exists.


### PR DESCRIPTION
I wanted to switch from Red/Black to AVL but had been using IteratorAt which was not defined in AVL.

This adds it. Exactly copy from Red/Black.

(Thanks for this excellent library.)