### PR TITLE
Implement Bitset

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Implementation of various data structures and algorithms in Go.
     - [HashSet](#hashset)
     - [TreeSet](#treeset)
     - [LinkedHashSet](#linkedhashset)
+    - [BitSet](#bitset)
   - [Stacks](#stacks)
     - [LinkedListStack](#linkedliststack)
     - [ArrayStack](#arraystack)
@@ -85,6 +86,7 @@ Containers are either ordered or unordered. All ordered containers provide [stat
 |   | [HashSet](#hashset)                   | no | no | no | index |
 |   | [TreeSet](#treeset)                   | yes | yes* | yes | index |
 |   | [LinkedHashSet](#linkedhashset)       | yes | yes* | yes | index |
+|   | [BitSet](#bitset)                     | yes | no | no | index |
 | [Stacks](#stacks) |
 |   | [LinkedListStack](#linkedliststack)   | yes | yes | no | index |
 |   | [ArrayStack](#arraystack)             | yes | yes* | no | index |
@@ -348,6 +350,36 @@ func main() {
 	set.Clear()                // empty
 	set.Empty()                // true
 	set.Size()                 // 0
+}
+```
+
+#### BitSet
+
+A [set](#sets) backed by a bit array for non-negative integer elements. Each element is represented as a single bit, providing O(1) add, remove, and membership operations with minimal memory overhead. The backing array grows automatically to accommodate new elements. Set operations (intersection, union, difference) are performed at the word level using bitwise operations, making them significantly faster than hash-based alternatives.
+
+Implements [Set](#sets), [JSONSerializer](#jsonserializer) and [JSONDeserializer](#jsondeserializer) interfaces.
+
+```go
+package main
+
+import "github.com/emirpasic/gods/sets/bitset"
+
+func main() {
+	set := bitset.New()    // empty
+	set.Add(1)             // 1
+	set.Add(2, 2, 3, 4, 5) // 1, 2, 3, 4, 5 (in ascending order, duplicates ignored)
+	set.Remove(4)          // 1, 2, 3, 5 (in ascending order)
+	set.Remove(2, 3)       // 1, 5 (in ascending order)
+	set.Contains(1)        // true
+	set.Contains(1, 5)     // true
+	set.Contains(1, 6)     // false
+	_ = set.Values()       // []int{1, 5} (in ascending order)
+	set.Clear()            // empty
+	set.Empty()            // true
+	set.Size()             // 0
+
+	// Pre-allocate for a known universe size
+	set = bitset.NewWithCapacity(1000) // pre-allocated for elements 0-999
 }
 ```
 

--- a/sets/bitset/bitset.go
+++ b/sets/bitset/bitset.go
@@ -1,0 +1,226 @@
+// Copyright (c) 2015, Emir Pasic. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package bitset implements a set backed by a bit array.
+//
+// Elements must be non-negative integers. The backing array grows automatically
+// to accommodate new elements.
+//
+// Structure is not thread safe.
+//
+// References: https://en.wikipedia.org/wiki/Bit_array
+package bitset
+
+import (
+	"fmt"
+	"math/bits"
+	"strings"
+
+	"github.com/emirpasic/gods/v2/sets"
+)
+
+// Assert Set implementation
+var _ sets.Set[int] = (*Set)(nil)
+
+// Set holds elements as bits in an array of uint64 words.
+type Set struct {
+	b    []uint64
+	size int
+}
+
+// New instantiates a new empty set and adds the passed values, if any, to the set.
+func New(values ...int) *Set {
+	set := &Set{}
+	if len(values) > 0 {
+		set.Add(values...)
+	}
+	return set
+}
+
+// NewWithCapacity instantiates a new empty set pre-allocated to hold elements
+// in the range [0, universe) and adds the passed values, if any, to the set.
+func NewWithCapacity(universe int, values ...int) *Set {
+	n := 0
+	if universe > 0 {
+		n = (universe-1)>>6 + 1
+	}
+	set := &Set{
+		b: make([]uint64, n),
+	}
+	if len(values) > 0 {
+		set.Add(values...)
+	}
+	return set
+}
+
+// grow ensures the backing array can accommodate element x.
+func (set *Set) grow(x int) {
+	needed := x>>6 + 1
+	if needed <= len(set.b) {
+		return
+	}
+	expanded := make([]uint64, needed)
+	copy(expanded, set.b)
+	set.b = expanded
+}
+
+// Add adds the items (one or more) to the set.
+// Panics if any element is negative.
+func (set *Set) Add(items ...int) {
+	for _, item := range items {
+		if item < 0 {
+			panic(fmt.Sprintf("bitset: negative element %d", item))
+		}
+		set.grow(item)
+		w, mask := item>>6, uint64(1)<<uint(item&63)
+		if set.b[w]&mask == 0 {
+			set.b[w] |= mask
+			set.size++
+		}
+	}
+}
+
+// Remove removes the items (one or more) from the set.
+// Panics if any element is negative.
+func (set *Set) Remove(items ...int) {
+	for _, item := range items {
+		if item < 0 {
+			panic(fmt.Sprintf("bitset: negative element %d", item))
+		}
+		w := item >> 6
+		if w >= len(set.b) {
+			continue
+		}
+		mask := uint64(1) << uint(item&63)
+		if set.b[w]&mask != 0 {
+			set.b[w] &^= mask
+			set.size--
+		}
+	}
+}
+
+// Contains checks if items (one or more) are present in the set.
+// All items have to be present in the set for the method to return true.
+// Returns true if no arguments are passed at all, i.e. set is always superset of empty set.
+// Panics if any element is negative.
+func (set *Set) Contains(items ...int) bool {
+	for _, item := range items {
+		if item < 0 {
+			panic(fmt.Sprintf("bitset: negative element %d", item))
+		}
+		w := item >> 6
+		if w >= len(set.b) {
+			return false
+		}
+		if set.b[w]&(uint64(1)<<uint(item&63)) == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+// Empty returns true if set does not contain any elements.
+func (set *Set) Empty() bool {
+	return set.size == 0
+}
+
+// Size returns number of elements within the set.
+func (set *Set) Size() int {
+	return set.size
+}
+
+// Clear clears all values in the set.
+func (set *Set) Clear() {
+	set.b = nil
+	set.size = 0
+}
+
+// Values returns all items in the set.
+// Elements are returned in ascending order.
+func (set *Set) Values() []int {
+	values := make([]int, 0, set.size)
+	for i, word := range set.b {
+		if word == 0 {
+			continue
+		}
+		base := i << 6 // i * 64
+		for word != 0 {
+			bit := bits.TrailingZeros64(word)
+			values = append(values, base+bit)
+			word &= word - 1 // clear lowest set bit
+		}
+	}
+	return values
+}
+
+// String returns a string representation of container.
+func (set *Set) String() string {
+	str := "BitSet\n"
+	items := []string{}
+	for _, v := range set.Values() {
+		items = append(items, fmt.Sprintf("%v", v))
+	}
+	str += strings.Join(items, ", ")
+	return str
+}
+
+// Intersection returns the intersection between two sets.
+// The new set consists of all elements that are both in "set" and "another".
+// Ref: https://en.wikipedia.org/wiki/Intersection_(set_theory)
+func (set *Set) Intersection(another *Set) *Set {
+	result := &Set{}
+	minLen := min(len(set.b), len(another.b))
+	if minLen == 0 {
+		return result
+	}
+	result.b = make([]uint64, minLen)
+	for i := 0; i < minLen; i++ {
+		result.b[i] = set.b[i] & another.b[i]
+		result.size += bits.OnesCount64(result.b[i])
+	}
+	return result
+}
+
+// Union returns the union of two sets.
+// The new set consists of all elements that are in "set" or "another" (possibly both).
+// Ref: https://en.wikipedia.org/wiki/Union_(set_theory)
+func (set *Set) Union(another *Set) *Set {
+	result := &Set{}
+	longer, shorter := set.b, another.b
+	if len(shorter) > len(longer) {
+		longer, shorter = shorter, longer
+	}
+	if len(longer) == 0 {
+		return result
+	}
+	result.b = make([]uint64, len(longer))
+	copy(result.b, longer)
+	for i, w := range shorter {
+		result.b[i] |= w
+	}
+	for _, w := range result.b {
+		result.size += bits.OnesCount64(w)
+	}
+	return result
+}
+
+// Difference returns the difference between two sets.
+// The new set consists of all elements that are in "set" but not in "another".
+// Ref: https://proofwiki.org/wiki/Definition:Set_Difference
+func (set *Set) Difference(another *Set) *Set {
+	result := &Set{}
+	if len(set.b) == 0 {
+		return result
+	}
+	result.b = make([]uint64, len(set.b))
+	minLen := min(len(set.b), len(another.b))
+	for i := 0; i < minLen; i++ {
+		result.b[i] = set.b[i] &^ another.b[i]
+	}
+	copy(result.b[minLen:], set.b[minLen:])
+	for _, w := range result.b {
+		result.size += bits.OnesCount64(w)
+	}
+	return result
+}

--- a/sets/bitset/bitset_test.go
+++ b/sets/bitset/bitset_test.go
@@ -1,0 +1,495 @@
+// Copyright (c) 2015, Emir Pasic. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bitset
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestSetNew(t *testing.T) {
+	set := New(2, 1)
+
+	if actualValue := set.Size(); actualValue != 2 {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	if actualValue := set.Contains(1); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := set.Contains(2); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := set.Contains(3); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+}
+
+func TestSetNewWithCapacity(t *testing.T) {
+	set := NewWithCapacity(100, 2, 1)
+
+	if actualValue := set.Size(); actualValue != 2 {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	if actualValue := set.Contains(1); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := set.Contains(2); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := set.Contains(99); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+}
+
+func TestSetAdd(t *testing.T) {
+	set := New()
+	set.Add()
+	set.Add(1)
+	set.Add(2)
+	set.Add(2, 3)
+	set.Add()
+	if actualValue := set.Empty(); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+	if actualValue := set.Size(); actualValue != 3 {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+}
+
+func TestSetAddAutoGrow(t *testing.T) {
+	set := NewWithCapacity(10)
+	set.Add(5)
+	set.Add(100) // beyond initial capacity, should grow
+	if actualValue := set.Size(); actualValue != 2 {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	if actualValue := set.Contains(5); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := set.Contains(100); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
+func TestSetAddNegativePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("Expected panic for negative element")
+		}
+	}()
+	set := New()
+	set.Add(-1)
+}
+
+func TestSetContains(t *testing.T) {
+	set := New()
+	set.Add(3, 1, 2)
+	set.Add(2, 3)
+	set.Add()
+	if actualValue := set.Contains(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := set.Contains(1); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := set.Contains(1, 2, 3); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	if actualValue := set.Contains(1, 2, 3, 4); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+}
+
+func TestSetContainsBeyondCapacity(t *testing.T) {
+	set := NewWithCapacity(10)
+	set.Add(5)
+	// Element beyond backing array should return false, not panic
+	if actualValue := set.Contains(1000); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+}
+
+func TestSetRemove(t *testing.T) {
+	set := New()
+	set.Add(3, 1, 2)
+	set.Remove()
+	if actualValue := set.Size(); actualValue != 3 {
+		t.Errorf("Got %v expected %v", actualValue, 3)
+	}
+	set.Remove(1)
+	if actualValue := set.Size(); actualValue != 2 {
+		t.Errorf("Got %v expected %v", actualValue, 2)
+	}
+	set.Remove(3)
+	set.Remove(3) // remove non-existent, should be no-op
+	set.Remove()
+	set.Remove(2)
+	if actualValue := set.Size(); actualValue != 0 {
+		t.Errorf("Got %v expected %v", actualValue, 0)
+	}
+}
+
+func TestSetRemoveBeyondCapacity(t *testing.T) {
+	set := NewWithCapacity(10)
+	set.Add(5)
+	// Remove beyond backing array should be no-op, not panic
+	set.Remove(1000)
+	if actualValue := set.Size(); actualValue != 1 {
+		t.Errorf("Got %v expected %v", actualValue, 1)
+	}
+}
+
+func TestSetValues(t *testing.T) {
+	set := New()
+	set.Add(3, 1, 2, 100, 65)
+	values := set.Values()
+	if len(values) != 5 {
+		t.Errorf("Got %v expected %v", len(values), 5)
+	}
+	// Values should be in ascending order
+	expected := []int{1, 2, 3, 65, 100}
+	for i, v := range values {
+		if v != expected[i] {
+			t.Errorf("Got %v expected %v at index %d", v, expected[i], i)
+		}
+	}
+}
+
+func TestSetEmpty(t *testing.T) {
+	set := New()
+	if actualValue := set.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+	set.Add(1)
+	if actualValue := set.Empty(); actualValue != false {
+		t.Errorf("Got %v expected %v", actualValue, false)
+	}
+	set.Remove(1)
+	if actualValue := set.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
+func TestSetClear(t *testing.T) {
+	set := New()
+	set.Add(1, 2, 3)
+	set.Clear()
+	if actualValue := set.Size(); actualValue != 0 {
+		t.Errorf("Got %v expected %v", actualValue, 0)
+	}
+	if actualValue := set.Empty(); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
+func TestSetSerialization(t *testing.T) {
+	set := New()
+	set.Add(1, 2, 3)
+
+	var err error
+	assert := func() {
+		if actualValue, expectedValue := set.Size(), 3; actualValue != expectedValue {
+			t.Errorf("Got %v expected %v", actualValue, expectedValue)
+		}
+		if actualValue := set.Contains(1, 2, 3); actualValue != true {
+			t.Errorf("Got %v expected %v", actualValue, true)
+		}
+		if err != nil {
+			t.Errorf("Got error %v", err)
+		}
+	}
+
+	assert()
+
+	bytes, err := set.ToJSON()
+	assert()
+
+	err = set.FromJSON(bytes)
+	assert()
+
+	bytes, err = json.Marshal([]interface{}{1, 2, 3, set})
+	if err != nil {
+		t.Errorf("Got error %v", err)
+	}
+
+	err = json.Unmarshal([]byte(`[1,2,3]`), &set)
+	if err != nil {
+		t.Errorf("Got error %v", err)
+	}
+	assert()
+}
+
+func TestSetString(t *testing.T) {
+	c := New()
+	c.Add(1)
+	if !strings.HasPrefix(c.String(), "BitSet") {
+		t.Errorf("String should start with container name")
+	}
+}
+
+func TestSetIntersection(t *testing.T) {
+	set := New()
+	another := New()
+
+	intersection := set.Intersection(another)
+	if actualValue, expectedValue := intersection.Size(), 0; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+
+	set.Add(1, 2, 3, 4)
+	another.Add(3, 4, 5, 6)
+
+	intersection = set.Intersection(another)
+
+	if actualValue, expectedValue := intersection.Size(), 2; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if actualValue := intersection.Contains(3, 4); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
+func TestSetUnion(t *testing.T) {
+	set := New()
+	another := New()
+
+	union := set.Union(another)
+	if actualValue, expectedValue := union.Size(), 0; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+
+	set.Add(1, 2, 3, 4)
+	another.Add(3, 4, 5, 6)
+
+	union = set.Union(another)
+
+	if actualValue, expectedValue := union.Size(), 6; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if actualValue := union.Contains(1, 2, 3, 4, 5, 6); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
+func TestSetDifference(t *testing.T) {
+	set := New()
+	another := New()
+
+	difference := set.Difference(another)
+	if actualValue, expectedValue := difference.Size(), 0; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+
+	set.Add(1, 2, 3, 4)
+	another.Add(3, 4, 5, 6)
+
+	difference = set.Difference(another)
+
+	if actualValue, expectedValue := difference.Size(), 2; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if actualValue := difference.Contains(1, 2); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
+func TestSetIntersectionMismatchedSize(t *testing.T) {
+	set := New()
+	another := New()
+	set.Add(1, 2, 100)
+	another.Add(2, 3)
+
+	intersection := set.Intersection(another)
+	if actualValue, expectedValue := intersection.Size(), 1; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if actualValue := intersection.Contains(2); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
+func TestSetUnionMismatchedSize(t *testing.T) {
+	set := New()
+	another := New()
+	set.Add(1, 2, 100)
+	another.Add(2, 3)
+
+	union := set.Union(another)
+	if actualValue, expectedValue := union.Size(), 4; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if actualValue := union.Contains(1, 2, 3, 100); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
+func TestSetDifferenceMismatchedSize(t *testing.T) {
+	set := New()
+	another := New()
+	set.Add(1, 2, 100)
+	another.Add(2, 3)
+
+	difference := set.Difference(another)
+	if actualValue, expectedValue := difference.Size(), 2; actualValue != expectedValue {
+		t.Errorf("Got %v expected %v", actualValue, expectedValue)
+	}
+	if actualValue := difference.Contains(1, 100); actualValue != true {
+		t.Errorf("Got %v expected %v", actualValue, true)
+	}
+}
+
+func benchmarkContains(b *testing.B, set *Set, size int) {
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < size; n++ {
+			set.Contains(n)
+		}
+	}
+}
+
+func benchmarkAdd(b *testing.B, set *Set, size int) {
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < size; n++ {
+			set.Add(n)
+		}
+	}
+}
+
+func benchmarkRemove(b *testing.B, set *Set, size int) {
+	for i := 0; i < b.N; i++ {
+		for n := 0; n < size; n++ {
+			set.Remove(n)
+		}
+	}
+}
+
+func BenchmarkBitSetContains100(b *testing.B) {
+	b.StopTimer()
+	size := 100
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkContains(b, set, size)
+}
+
+func BenchmarkBitSetContains1000(b *testing.B) {
+	b.StopTimer()
+	size := 1000
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkContains(b, set, size)
+}
+
+func BenchmarkBitSetContains10000(b *testing.B) {
+	b.StopTimer()
+	size := 10000
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkContains(b, set, size)
+}
+
+func BenchmarkBitSetContains100000(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkContains(b, set, size)
+}
+
+func BenchmarkBitSetAdd100(b *testing.B) {
+	b.StopTimer()
+	size := 100
+	set := New()
+	b.StartTimer()
+	benchmarkAdd(b, set, size)
+}
+
+func BenchmarkBitSetAdd1000(b *testing.B) {
+	b.StopTimer()
+	size := 1000
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkAdd(b, set, size)
+}
+
+func BenchmarkBitSetAdd10000(b *testing.B) {
+	b.StopTimer()
+	size := 10000
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkAdd(b, set, size)
+}
+
+func BenchmarkBitSetAdd100000(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkAdd(b, set, size)
+}
+
+func BenchmarkBitSetRemove100(b *testing.B) {
+	b.StopTimer()
+	size := 100
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkRemove(b, set, size)
+}
+
+func BenchmarkBitSetRemove1000(b *testing.B) {
+	b.StopTimer()
+	size := 1000
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkRemove(b, set, size)
+}
+
+func BenchmarkBitSetRemove10000(b *testing.B) {
+	b.StopTimer()
+	size := 10000
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkRemove(b, set, size)
+}
+
+func BenchmarkBitSetRemove100000(b *testing.B) {
+	b.StopTimer()
+	size := 100000
+	set := New()
+	for n := 0; n < size; n++ {
+		set.Add(n)
+	}
+	b.StartTimer()
+	benchmarkRemove(b, set, size)
+}

--- a/sets/bitset/serialization.go
+++ b/sets/bitset/serialization.go
@@ -1,0 +1,41 @@
+// Copyright (c) 2015, Emir Pasic. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package bitset
+
+import (
+	"encoding/json"
+
+	"github.com/emirpasic/gods/v2/containers"
+)
+
+// Assert Serialization implementation
+var _ containers.JSONSerializer = (*Set)(nil)
+var _ containers.JSONDeserializer = (*Set)(nil)
+
+// ToJSON outputs the JSON representation of the set.
+func (set *Set) ToJSON() ([]byte, error) {
+	return json.Marshal(set.Values())
+}
+
+// FromJSON populates the set from the input JSON representation.
+func (set *Set) FromJSON(data []byte) error {
+	var elements []int
+	err := json.Unmarshal(data, &elements)
+	if err == nil {
+		set.Clear()
+		set.Add(elements...)
+	}
+	return err
+}
+
+// UnmarshalJSON @implements json.Unmarshaler
+func (set *Set) UnmarshalJSON(bytes []byte) error {
+	return set.FromJSON(bytes)
+}
+
+// MarshalJSON @implements json.Marshaler
+func (set *Set) MarshalJSON() ([]byte, error) {
+	return set.ToJSON()
+}


### PR DESCRIPTION
## Summary

Adds a `BitSet` data structure under `sets/bitset/` that implements the `sets.Set[int]` interface using a bit array (`[]uint64`) as its backing store.

A bitset maps non-negative integer elements to individual bits, providing O(1) add, remove, and contains operations with significantly lower memory overhead than hash-based sets for dense integer ranges.

## Design Decisions

- **Non-generic, concrete `int`**: Unlike `HashSet[T]` and `TreeSet[T]`, a bitset can only represent non-negative integers. The struct satisfies `sets.Set[int]` directly rather than introducing a generic parameter that would be misleading.
- **`uint64` backing array**: Unsigned words avoid sign-extension on right-shift during bit extraction. The element type remains `int` per the interface.
- **Auto-growing**: The backing array grows on `Add` if the element exceeds current capacity. `NewWithCapacity(universe)` is available for pre-allocation when the range is known upfront.
- **Tracked `size` field**: Incremented/decremented on add/remove to provide O(1) `Size()` and `Empty()`.
- **Negative elements panic**: A negative integer has no valid bit position. This is a programming error, not a runtime condition.
- **Bitwise set operations**: `Intersection` (AND), `Union` (OR), and `Difference` (AND-NOT) operate at the word level — O(n/64) where n is the universe size, compared to O(n) for hash-based sets.

## Files

| File | Purpose |
|---|---|
| `sets/bitset/bitset.go` | Core implementation, interface assertion, set operations |
| `sets/bitset/serialization.go` | JSON serialization following `hashset/serialization.go` pattern |
| `sets/bitset/bitset_test.go` | 20 unit tests + benchmarks at 100/1K/10K/100K sizes |

## Test Results

```
PASS: TestSetNew
PASS: TestSetNewWithCapacity
PASS: TestSetAdd
PASS: TestSetAddAutoGrow
PASS: TestSetAddNegativePanics
PASS: TestSetContains
PASS: TestSetContainsBeyondCapacity
PASS: TestSetRemove
PASS: TestSetRemoveBeyondCapacity
PASS: TestSetValues
PASS: TestSetEmpty
PASS: TestSetClear
PASS: TestSetSerialization
PASS: TestSetString
PASS: TestSetIntersection
PASS: TestSetUnion
PASS: TestSetDifference
PASS: TestSetIntersectionMismatchedSize
PASS: TestSetUnionMismatchedSize
PASS: TestSetDifferenceMismatchedSize
```